### PR TITLE
Fix dojox/form/manager/_Mixin to use getChildren if getDescendants doesn't exist, fixes #17173

### DIFF
--- a/form/Manager.js
+++ b/form/Manager.js
@@ -1,5 +1,5 @@
 define([
-	"dijit/_WidgetBase",
+	"dijit/_Widget",
 	"dijit/_AttachMixin",
 	"dijit/_WidgetsInTemplateMixin",
 	"./manager/_Mixin",
@@ -10,9 +10,9 @@ define([
 	"./manager/_DisplayMixin",
 	"./manager/_ClassMixin",
 	"dojo/_base/declare"
-], function(_WidgetBase, _AttachMixin, _WidgetsInTemplateMixin, _Mixin, _NodeMixin, _FormMixin, _ValueMixin, _EnableMixin, _DisplayMixin, _ClassMixin, declare){
+], function(_Widget, _AttachMixin, _WidgetsInTemplateMixin, _Mixin, _NodeMixin, _FormMixin, _ValueMixin, _EnableMixin, _DisplayMixin, _ClassMixin, declare){
 
-return declare("dojox.form.Manager", [ _WidgetBase, _WidgetsInTemplateMixin, _AttachMixin, _Mixin, _NodeMixin, _FormMixin, _ValueMixin, _EnableMixin, _DisplayMixin, _ClassMixin ], {
+return declare("dojox.form.Manager", [ _Widget, _WidgetsInTemplateMixin, _AttachMixin, _Mixin, _NodeMixin, _FormMixin, _ValueMixin, _EnableMixin, _DisplayMixin, _ClassMixin ], {
 	// summary:
 	//		The widget to orchestrate dynamic forms.
 	// description:


### PR DESCRIPTION
`dojox/form/manager/_Mixin` blindly assumed a _Widget superclass and depended on `widget.getDescendants`. This has been fixed to use `widget.getChildren` if `widget.getDescendants` doesn't exsit, thus assuming a _WidgetBase superclass at the very least. 

As an added bonus of this fix, `dojox/form/Manager` was able to ditch the _Widget dep and use _WidgetBase instead.

cc @dylans from an earlier discussion on this one
