### PR TITLE
Support dtl loop over objects assigning key/value pairs.

### DIFF
--- a/dtl/tag/logic.js
+++ b/dtl/tag/logic.js
@@ -134,7 +134,7 @@ define([
 			var arred = [];
 			if(isObject){
 				for(var key in items){
-					arred.push(items[key]);
+					arred.push([key, items[key]]);
 				}
 			}else{
 				arred = items;


### PR DESCRIPTION
Refer [#17251](https://bugs.dojotoolkit.org/ticket/17251)

In summary, the for loop tag over objects drops the key, so syntax like:

`{% for key, value in object %}`

Doesn't work as expected.

This patch adjusts the `ForNode` so that objects are assigned as key/value pairs to the assignment arguments.
