### PR TITLE
Change inheritance from _Widget to _WidgetBase

### DIFF
--- a/geo/openlayers/widget/Map.js
+++ b/geo/openlayers/widget/Map.js
@@ -4,7 +4,7 @@ define([
 	"dojo/_base/array",
 	"dojo/dom-geometry",
 	"dojo/query",
-	"dijit/_Widget",
+	"dijit/_WidgetBase",
 	"../_base",
 	"../Map",
 	"../Layer",


### PR DESCRIPTION
It is currently recommended to inherit from dijit/_WidgetBase directly when defining custom widgets.
