### PR TITLE
Fix for #17103 dojox.form.CheckedMultiSelect menu doesn't have checkboxes

### DIFF
--- a/form/CheckedMultiSelect.js
+++ b/form/CheckedMultiSelect.js
@@ -212,7 +212,7 @@ var formCheckedMultiSelectMenuItem = declare("dojox.form._CheckedMultiSelectMenu
 	parent: null,
 
 	// icon of the checkbox/radio button
-	_iconClass: "",
+	iconClass: "",
 
 	postMixInProperties: function(){
 		// summary:

--- a/mvc/tests/doh/doh_mvc_form-kitchensink.html
+++ b/mvc/tests/doh/doh_mvc_form-kitchensink.html
@@ -319,12 +319,16 @@
 
 					numBox.startup();
 
-	/*
+
 					doh.register("Check initial programatic values and bindings for select widget only", [
 						{
 							name: "InitialSelectOnly",
 							runTest: function(){
-								console.log("This test is commented out because it will fail if _FromSelectWidget is not updated to setup the store in postCreate instead of startup, see ticket 13372 for details.");
+								var wid, textboxval, outputval;
+								wid = registry.byId("sel");
+								textboxval = registry.byId("seltext").value;
+								outputval = registry.byId("selOutput").value;
+								//console.log("This test was commented out because it will fail if _FromSelectWidget is not updated to setup the store in postCreate instead of startup, see ticket 13372 for details.");
 								// Test Select
 								doh.is("1",wid.get("value"),"This test will fail if _FromSelectWidget is not updated to setup the store in postCreate instead of startup, see ticket 13372 for details.");
 								doh.is(registry.byId("seltext").value,registry.byId("sel").get("value"),"wid.get(\"value\") should be set same as textboxval");
@@ -332,7 +336,7 @@
 							}
 						}
 					]);
-	*/
+
 
 					doh.register("Check initial values and bindings widgets other than select", [
 						{


### PR DESCRIPTION
This fix in dojox/form/CheckedMultiSelect.js is for the part of #17103 which has to do with the menu not displaying the checkboxes.  I have also updated the mvc test which tests the problem which introduced the other problem (the empty combobox) reported in #17103, to be sure the fix for this does not regress that fix.
