### PR TITLE
#17399: Items of disabled CheckedMultiSelect not disabled

### DIFF
--- a/form/CheckedMultiSelect.js
+++ b/form/CheckedMultiSelect.js
@@ -346,6 +346,9 @@ var formCheckedMultiSelect = declare("dojox.form.CheckedMultiSelect", FormSelect
 			}, this.comboButtonNode);
 		}
 		this.inherited(arguments);
+		// pass disabled state onto children, who do not exist at the time these methods are automatically called.
+		this.set("disabled",this.get("disabled"))
+		this.set("readOnly",this.get("readOnly"))
 	},
 
 	_onMouseDown: function(e){

--- a/form/tests/test_CheckedMultiSelect.html
+++ b/form/tests/test_CheckedMultiSelect.html
@@ -355,6 +355,45 @@
 				</script>
 				Get Displayed Value
 			</button>
+			<hr>
+			<h1>Disabled select (shouldn't be able to check items)</h1>
+			<select data-dojo-props='multiple:"true", name:"multiselect", disabled:true' data-dojo-type="dojox.form.CheckedMultiSelect">
+				<option value="TN">
+					Tennessee
+				</option>
+				<option value="VA" selected="selected">
+					Virginia
+				</option>
+				<option value="WA" selected="selected">
+					Washington
+				</option>
+				<option value="FL">
+					Florida
+				</option>
+				<option value="CA">
+					California
+				</option>
+			</select>
+			<hr>
+			<h1>ReadOnly select (shouldn't be able to check items, but checkboxes should still be colored)</h1>
+			<select data-dojo-props='multiple:"true", name:"multiselect", readOnly:true' data-dojo-type="dojox.form.CheckedMultiSelect">
+				<option value="TN">
+					Tennessee
+				</option>
+				<option value="VA" selected="selected">
+					Virginia
+				</option>
+				<option value="WA" selected="selected">
+					Washington
+				</option>
+				<option value="FL">
+					Florida
+				</option>
+				<option value="CA">
+					California
+				</option>
+			</select>
+
 		</form>
 	</body>
 </html>


### PR DESCRIPTION
Call set("disabled") and set("readOnly") in startup so children are updated appropriately. Added test cases. Fixes #17399.
