### PR TITLE
Fix for ticket #17416 (https://bugs.dojotoolkit.org/ticket/17416)

### DIFF
--- a/mobile/scrollable.js
+++ b/mobile/scrollable.js
@@ -126,7 +126,7 @@ define([
 		_parentPadBorderExtentsBottom: 0,
 
 		// boolean that signal if the user have moved in (one of) the scroll direction(s) since touch start (moved under the threshold is ignored)
-		_fingerMovedSinceTouchStart: false,
+		_moved: false,
 
 		init: function(/*Object?*/params){
 			// summary:
@@ -468,7 +468,7 @@ define([
 			this._posX = [this.touchStartX];
 			this._posY = [this.touchStartY];
 			this._locked = false;
-			this._fingerMovedSinceTouchStart = false;
+			this._moved = false;
 
 			if(!this.isFormElement(e.target)){
 				this.propagatable ? e.preventDefault() : event.stop(e);
@@ -507,7 +507,7 @@ define([
 						return;
 					}
 				}
-				this._fingerMovedSinceTouchStart = true;
+				this._moved = true;
 				this.addCover();
 				this.showScrollBar();
 			}
@@ -540,7 +540,7 @@ define([
 			var max = 10;
 			var n = this._time.length; // # of samples
 			if(n >= 2){
-				this._fingerMovedSinceTouchStart = true;
+				this._moved = true;
 				// Check the direction of the finger move.
 				// If the direction has been changed, discard the old data.
 				var d0, d1;
@@ -604,7 +604,7 @@ define([
 				this._conn = null;
 
 				var clicked = false;
-				if(!this._aborted && !this._fingerMovedSinceTouchStart){
+				if(!this._aborted && !this._moved){
 					clicked = true;
 				}
 				if(clicked){ // clicked, not dragged or flicked


### PR DESCRIPTION
Problem fixed by replacing the faulty _fingerMovedSinceTouchStart method by a flag of the same name that hold a correct value even if scroll direction is changing at some point.
