### PR TITLE
Update _base.js

### DIFF
--- a/gfx/_base.js
+++ b/gfx/_base.js
@@ -106,6 +106,7 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 			measuringNode = domConstruct.create("div", {style: {
 				position: "absolute",
 				top: "-10000px",
+				visibility: "hidden",
 				left: "0"
 			}}, win.body());
 		}


### PR DESCRIPTION
Screen reader and VoiceOver on IPHONE will try to read this generated Div tag content to the user. I added visibility:hidden attribute to help the screen readers to avoid this temp content in the DOM tree, since it is poorly designed here.
