### PR TITLE
Prevent _dbpostscript() from running twice for widgets with dojox/mvc/_Controller mixed in, fixes #17439.

### DIFF
--- a/mvc/_Controller.js
+++ b/mvc/_Controller.js
@@ -12,7 +12,7 @@ define([
 
 			// If there is dijit/_WidgetBase in upper class hierarchy (happens when this descendant is mixed into a widget), let _WidgetBase do all work
 			if(this._applyAttributes){
-				this.inherited(arguments);
+				return this.inherited(arguments);
 			}
 			// Look for dojox/mvc/at handles in the parameters
 			this._dbpostscript(params, srcNodeRef);

--- a/mvc/tests/doh/_Controller.js
+++ b/mvc/tests/doh/_Controller.js
@@ -1,13 +1,15 @@
 define([
 	"doh",
 	"dojo/_base/declare",
+	"dojo/Stateful",
 	"dijit/registry",
 	"dijit/_WidgetBase",
 	"dijit/_TemplatedMixin",
 	"dijit/_WidgetsInTemplateMixin",
-	"../doh/_Controller",
+	"dojox/mvc/at",
+	"dojox/mvc/_Controller",
 	"dojo/text!../templates/_ControllerInTemplate.html"
-], function(doh, declare, registry, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, _Controller, template){
+], function(doh, declare, Stateful, registry, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, at, _Controller, template){
 	doh.register("dojox.mvc.tests.doh._Controller", [
 		function destroyFromWidgetsInTemplate(){
 			var w = new (declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
@@ -19,6 +21,15 @@ define([
 			w.destroy();
 			doh.f(registry.byId(id), "The controller should have been removed from registry along with the template widget");
 			doh.t(ctrl._destroyed, "The controller should have been marked as destroyed along with the template widget");
+		},
+		function useWithDijit(){
+			var model = new Stateful(),
+				w = new (declare([_WidgetBase, _Controller], {}))({
+					foo: at(model, "foo")
+				});
+			w.startup();
+			model.set("foo", "Foo");
+			doh.is("Foo", w.get("foo"), "Update to model should be reflected to _WidgetBase/Controller mixin");
 		}
 	]);
 });


### PR DESCRIPTION
It happened because the code runs an unnecessary path in that condition. Test case included.
