### PR TITLE
Fixes #17239. Dock containerNode never created due to a typo.

### DIFF
--- a/layout/Dock.js
+++ b/layout/Dock.js
@@ -15,7 +15,7 @@ var Dock = declare("dojox.layout.Dock",[_WidgetBase, _TemplatedMixin],{
 	//		A widget that attaches to a node and keeps track of incoming / outgoing FloatingPanes
 	//		and handles layout
 
-	templateString: '<div class="dojoxDock"><ul dojo-dojo-attach-point="containerNode" class="dojoxDockList"></ul></div>',
+	templateString: '<div class="dojoxDock"><ul data-dojo-attach-point="containerNode" class="dojoxDockList"></ul></div>',
 
 	// _docked: [private] Array
 	//		array of panes currently in our dock


### PR DESCRIPTION
Fixes the bug described here: https://bugs.dojotoolkit.org/ticket/17239
