### PR TITLE
Added posibility to set style (CSS class) of TabBarButton's badge

### DIFF
--- a/mobile/TabBarButton.js
+++ b/mobile/TabBarButton.js
@@ -69,6 +69,10 @@ define([
 		// badge: String
 		//		A string to show on a badge. (ex. "12")
 		badge: "",
+		
+		// badgeClassName: [const] String
+                //                A CSS class name of a badge DOM node.
+                badgeClassName: "mblDomButtonRedBadge",
 
 		/* internal properties */	
 		baseClass: "mblTabBarButton",
@@ -266,7 +270,10 @@ define([
 
 		_setBadgeAttr: function(/*String*/value){
 			if(!this.badgeObj){
-				this.badgeObj = new Badge({fontSize:11});
+				this.badgeObj = new Badge({
+					fontSize: 11,
+					className: this.badgeClassName
+				});
 				domStyle.set(this.badgeObj.domNode, {
 					position: "absolute",
 					top: "0px",


### PR DESCRIPTION
Currently it is very inconvinient to change class of TabBarButton's badge. Eg.

```
// ensure tab_button.badgeObj is created
tab_button._setBadgeAttr(null);
// remove default red style
domClass.remove(tab_button.badgeObj.domNode,
                tab_button.badgeObj.className);
tab_button.badgeObj.className = 'mblDomButtonGrayBadge';
// add new gray style
domClass.add(tab_button.badgeObj.domNode,
             tab_button.badgeObj.className);
```
