### PR TITLE
fixes #17665 border-radius not supported anymore on Samsung Android 4.2....

### DIFF
--- a/mobile/themes/android/Accordion.css
+++ b/mobile/themes/android/Accordion.css
@@ -8,6 +8,10 @@
   margin: 7px 9px 16px 9px;
   padding: 0;
   border: 1px solid #adaaad;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
 }
 .mblAccordionRoundRect .mblAccordionTitle:first-child {

--- a/mobile/themes/android/Button.css
+++ b/mobile/themes/android/Button.css
@@ -11,6 +11,10 @@
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
   border-color: #9cacc0;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   color: black;
   font-size: 13px;

--- a/mobile/themes/android/CheckBox.css
+++ b/mobile/themes/android/CheckBox.css
@@ -15,6 +15,10 @@
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #9cacc0;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblCheckBoxSelected {

--- a/mobile/themes/android/IconMenu.css
+++ b/mobile/themes/android/IconMenu.css
@@ -2,6 +2,10 @@
 .mblIconMenu {
   width: 100%;
   height: 100%;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);

--- a/mobile/themes/android/PageIndicator.css
+++ b/mobile/themes/android/PageIndicator.css
@@ -16,6 +16,10 @@
   height: 6px;
   font-size: 1px;
   background-color: #949294;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblPageIndicatorDotSelected {

--- a/mobile/themes/android/ProgressBar.css
+++ b/mobile/themes/android/ProgressBar.css
@@ -1,6 +1,10 @@
 /* dojox.mobile.ProgressBar */
 .mblProgressBar {
   position: relative;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   height: 22px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#545454), to(#414141), color-stop(0.3, #313031), color-stop(0.85, #293031));
@@ -18,6 +22,10 @@
   height: 22px;
 }
 .mblProgressBarComplete {
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
 }
 .mblProgressBarNotStarted {

--- a/mobile/themes/android/ProgressIndicator.css
+++ b/mobile/themes/android/ProgressIndicator.css
@@ -33,6 +33,10 @@
   -webkit-transform-origin: 0 2px;
   transform-origin: 0 2px;
   background-color: #c0c0c0;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblProg0 {

--- a/mobile/themes/android/RadioButton.css
+++ b/mobile/themes/android/RadioButton.css
@@ -6,6 +6,10 @@
   height: 1em;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 0.5em;
+  border-top-left-radius: 0.5em;
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
   border-radius: 0.5em;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#fdfdfd), to(#cecece), color-stop(0.5, #f8f8f8), color-stop(0.5, #eeeeee));
   background-image: linear-gradient(to bottom, #fdfdfd 0%, #f8f8f8 50%, #eeeeee 50%, #cecece 100%);

--- a/mobile/themes/android/RoundRect.css
+++ b/mobile/themes/android/RoundRect.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 8px;
   border: 1px solid #adaaad;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
   background-color: #000000;
   color: white;

--- a/mobile/themes/android/RoundRectList.css
+++ b/mobile/themes/android/RoundRectList.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 0;
   border: 1px solid #adaaad;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
   background-color: #000000;
 }

--- a/mobile/themes/android/SimpleDialog.css
+++ b/mobile/themes/android/SimpleDialog.css
@@ -9,6 +9,10 @@
   width: 262px;
 }
 .mblSimpleDialogDecoration {
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   background-color: rgba(64, 64, 64, 0.85);
   border: 2px solid #eeeeee;

--- a/mobile/themes/android/Slider.css
+++ b/mobile/themes/android/Slider.css
@@ -3,6 +3,10 @@
   margin: 15px;
   border-style: inset;
   border-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#bdbebd), to(#f7f3f7));
   background-image: linear-gradient(to bottom, #bdbebd 0%, #f7f3f7 100%);
@@ -33,6 +37,10 @@
   left: 50%;
 }
 .mblSliderProgressBar {
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#00a200), to(#00d300), color-stop(0.2, #00ba00), color-stop(0.2, #00ba00));
   background-image: linear-gradient(to bottom, #00a200 0%, #00ba00 20%, #00ba00 20%, #00d300 100%);
@@ -43,6 +51,10 @@
   height: 18px;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#9c9a9c), to(#848284));
   background-image: linear-gradient(to bottom, #9c9a9c 0%, #848284 100%);

--- a/mobile/themes/android/SpinWheel.css
+++ b/mobile/themes/android/SpinWheel.css
@@ -8,6 +8,10 @@
   border-left: solid 3px #000000;
   border-right: solid 3px #000000;
   color: #000000;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblSpinWheelBar {

--- a/mobile/themes/android/Switch.css
+++ b/mobile/themes/android/Switch.css
@@ -88,6 +88,10 @@
   left: -53px;
 }
 .mblSwSquareShape .mblSwitchBg {
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwSquareShape .mblSwitchBgRight {
@@ -96,6 +100,10 @@
 .mblSwSquareShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwSquareShape .mblSwitchText {
@@ -113,6 +121,10 @@
 }
 .mblSwRoundShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape1 .mblSwitchBgRight {
@@ -121,6 +133,10 @@
 .mblSwRoundShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape1 .mblSwitchText {
@@ -137,6 +153,10 @@
   left: -51px;
 }
 .mblSwRoundShape2 .mblSwitchBg {
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape2 .mblSwitchBgRight {
@@ -145,6 +165,10 @@
 .mblSwRoundShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape2 .mblSwitchText {
@@ -162,6 +186,10 @@
 }
 .mblSwArcShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape1 .mblSwitchBgRight {
@@ -170,6 +198,10 @@
 .mblSwArcShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape1 .mblSwitchText {
@@ -186,6 +218,10 @@
   left: -51px;
 }
 .mblSwArcShape2 .mblSwitchBg {
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape2 .mblSwitchBgRight {
@@ -194,6 +230,10 @@
 .mblSwArcShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape2 .mblSwitchText {
@@ -210,6 +250,10 @@
   left: -53px;
 }
 .mblSwDefaultShape .mblSwitchBg {
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwDefaultShape .mblSwitchBgRight {
@@ -218,6 +262,10 @@
 .mblSwDefaultShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwDefaultShape .mblSwitchText {

--- a/mobile/themes/android/TabBar.css
+++ b/mobile/themes/android/TabBar.css
@@ -60,6 +60,10 @@
   color: white;
 }
 .mblTabBarTabBar .mblTabBarButtonSelected {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   background-color: #404040;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#484848), to(#242424));

--- a/mobile/themes/android/TextArea.css
+++ b/mobile/themes/android/TextArea.css
@@ -6,6 +6,10 @@
   font-family: Helvetica;
   font-size: 13px;
   border-color: #9cacc0;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 /* dojox.mobile.ExpandingTextArea */

--- a/mobile/themes/android/TextBox.css
+++ b/mobile/themes/android/TextBox.css
@@ -6,5 +6,9 @@
   font-family: Helvetica;
   font-size: 13px;
   border-color: #9cacc0;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }

--- a/mobile/themes/android/ToggleButton.css
+++ b/mobile/themes/android/ToggleButton.css
@@ -12,6 +12,10 @@
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
   border-color: #9cacc0;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   font-size: 13px;
   color: black;

--- a/mobile/themes/android/ToolBarButton.css
+++ b/mobile/themes/android/ToolBarButton.css
@@ -38,6 +38,10 @@
   top: 5px;
   width: 20px;
   height: 19px;
+  border-bottom-left-radius: 1px;
+  border-top-left-radius: 1px;
+  border-top-right-radius: 1px;
+  border-bottom-right-radius: 1px;
   border-radius: 1px;
   -webkit-transform: scale(0.7, 1.05) rotate(45deg);
   transform: scale(0.7, 1.05) rotate(45deg);
@@ -53,6 +57,10 @@
   display: inline-block;
   position: relative;
   overflow: hidden;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   border: 1px solid #555555;
 }

--- a/mobile/themes/android/variables.less
+++ b/mobile/themes/android/variables.less
@@ -37,6 +37,10 @@
 
 .default-button-border-styles () {
 	border-color: #9cacc0;
+	border-bottom-left-radius: @default-button-border-radius;
+	border-top-left-radius: @default-button-border-radius;
+	border-top-right-radius: @default-button-border-radius;
+	border-bottom-right-radius: @default-button-border-radius;
 	border-radius: @default-button-border-radius;
 }
 
@@ -117,6 +121,10 @@
 	text-shadow: none;
 }
 .mblToolBarButtonArrow-styles () {
+	border-bottom-left-radius: 1px;
+	border-top-left-radius: 1px;
+	border-top-right-radius: 1px;
+	border-bottom-right-radius: 1px;
 	border-radius: 1px;
   .transform(scale(0.7, 1.05) rotate(45deg));
 	border: 1px solid #3a4655;
@@ -708,6 +716,10 @@
 
 // ProgressBar.less
 .mblProgressBar-styles () {
+	border-bottom-left-radius: 6px;
+	border-top-left-radius: 6px;
+	border-top-right-radius: 6px;
+	border-bottom-right-radius: 6px;
 	border-radius: 6px;
 	height: 22px;
 	.background-image-linear-gradient-top-bottom-2-stops(#545454, #414141, 0.3, #313031, 0.85, #293031);
@@ -719,6 +731,10 @@
 	height: 22px;
 }
 .mblProgressBarComplete-styles () {
+	border-bottom-left-radius: 6px;
+	border-top-left-radius: 6px;
+	border-top-right-radius: 6px;
+	border-bottom-right-radius: 6px;
 	border-radius: 6px;
 }
 .mblProgressBarNotStarted-styles () {

--- a/mobile/themes/blackberry/Accordion.css
+++ b/mobile/themes/blackberry/Accordion.css
@@ -8,6 +8,10 @@
   margin: 7px 9px 16px 9px;
   padding: 0;
   border: 1px solid #c6c7c6;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
 }
 .mblAccordionRoundRect .mblAccordionTitle:first-child {

--- a/mobile/themes/blackberry/IconMenu.css
+++ b/mobile/themes/blackberry/IconMenu.css
@@ -2,6 +2,10 @@
 .mblIconMenu {
   width: 100%;
   height: 100%;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);

--- a/mobile/themes/blackberry/PageIndicator.css
+++ b/mobile/themes/blackberry/PageIndicator.css
@@ -16,6 +16,10 @@
   height: 6px;
   font-size: 1px;
   background-color: #949294;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblPageIndicatorDotSelected {

--- a/mobile/themes/blackberry/ProgressIndicator.css
+++ b/mobile/themes/blackberry/ProgressIndicator.css
@@ -33,6 +33,10 @@
   -webkit-transform-origin: 0 2px;
   transform-origin: 0 2px;
   background-color: #c0c0c0;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblProg0 {

--- a/mobile/themes/blackberry/RadioButton.css
+++ b/mobile/themes/blackberry/RadioButton.css
@@ -6,6 +6,10 @@
   height: 1em;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 0.5em;
+  border-top-left-radius: 0.5em;
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
   border-radius: 0.5em;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#f7fbf7), to(#cecfd6), color-stop(0.5, #ced3ce));
   background-image: linear-gradient(to bottom, #f7fbf7 0%, #ced3ce 50%, #cecfd6 100%);

--- a/mobile/themes/blackberry/RoundRect.css
+++ b/mobile/themes/blackberry/RoundRect.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 8px;
   border: 1px solid #c6c7c6;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   background-color: #ffffff;
   color: black;

--- a/mobile/themes/blackberry/RoundRectList.css
+++ b/mobile/themes/blackberry/RoundRectList.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 0;
   border: 1px solid #c6c7c6;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   background-color: #ffffff;
 }

--- a/mobile/themes/blackberry/SimpleDialog.css
+++ b/mobile/themes/blackberry/SimpleDialog.css
@@ -9,6 +9,10 @@
   width: 262px;
 }
 .mblSimpleDialogDecoration {
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   background-color: #000000;
   border: none;

--- a/mobile/themes/blackberry/Slider.css
+++ b/mobile/themes/blackberry/Slider.css
@@ -3,6 +3,10 @@
   margin: 15px;
   border-style: inset;
   border-width: 1px;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#f7f3f7), to(#cec5d6), color-stop(0.5, #ced3ce));
   background-image: linear-gradient(to bottom, #f7f3f7 0%, #ced3ce 50%, #cec5d6 100%);
@@ -33,6 +37,10 @@
   left: 50%;
 }
 .mblSliderProgressBar {
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#088eef), to(#0851ad), color-stop(0.5, #0869c6));
   background-image: linear-gradient(to bottom, #088eef 0%, #0869c6 50%, #0851ad 100%);
@@ -43,6 +51,10 @@
   height: 18px;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#fafafa), to(#999999), color-stop(0.5, #bbbbbb));
   background-image: linear-gradient(to bottom, #fafafa 0%, #bbbbbb 50%, #999999 100%);

--- a/mobile/themes/blackberry/SpinWheel.css
+++ b/mobile/themes/blackberry/SpinWheel.css
@@ -8,6 +8,10 @@
   border-left: solid 3px #000000;
   border-right: solid 3px #000000;
   color: #000000;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblSpinWheelBar {

--- a/mobile/themes/blackberry/Switch.css
+++ b/mobile/themes/blackberry/Switch.css
@@ -88,6 +88,10 @@
   left: -53px;
 }
 .mblSwSquareShape .mblSwitchBg {
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
 }
 .mblSwSquareShape .mblSwitchBgRight {
@@ -96,6 +100,10 @@
 .mblSwSquareShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
 }
 .mblSwSquareShape .mblSwitchText {
@@ -113,6 +121,10 @@
 }
 .mblSwRoundShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape1 .mblSwitchBgRight {
@@ -121,6 +133,10 @@
 .mblSwRoundShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape1 .mblSwitchText {
@@ -137,6 +153,10 @@
   left: -51px;
 }
 .mblSwRoundShape2 .mblSwitchBg {
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape2 .mblSwitchBgRight {
@@ -145,6 +165,10 @@
 .mblSwRoundShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape2 .mblSwitchText {
@@ -162,6 +186,10 @@
 }
 .mblSwArcShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape1 .mblSwitchBgRight {
@@ -170,6 +198,10 @@
 .mblSwArcShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape1 .mblSwitchText {
@@ -186,6 +218,10 @@
   left: -51px;
 }
 .mblSwArcShape2 .mblSwitchBg {
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape2 .mblSwitchBgRight {
@@ -194,6 +230,10 @@
 .mblSwArcShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape2 .mblSwitchText {
@@ -210,6 +250,10 @@
   left: -53px;
 }
 .mblSwDefaultShape .mblSwitchBg {
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
 }
 .mblSwDefaultShape .mblSwitchBgRight {
@@ -218,6 +262,10 @@
 .mblSwDefaultShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
 }
 .mblSwDefaultShape .mblSwitchText {

--- a/mobile/themes/blackberry/TabBar.css
+++ b/mobile/themes/blackberry/TabBar.css
@@ -60,6 +60,10 @@
   color: #979797;
 }
 .mblTabBarTabBar .mblTabBarButtonSelected {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   background-color: #404040;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#484848), to(#242424), color-stop(0.5, #353535));

--- a/mobile/themes/blackberry/ToolBarButton.css
+++ b/mobile/themes/blackberry/ToolBarButton.css
@@ -54,6 +54,10 @@
   display: inline-block;
   position: relative;
   overflow: hidden;
+  border-bottom-left-radius: 5px;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
   border-radius: 5px;
   border: 1px outset #9cacc0;
 }

--- a/mobile/themes/common/Accordion.less
+++ b/mobile/themes/common/Accordion.less
@@ -8,6 +8,10 @@
 	margin: 7px 9px 16px 9px;
 	padding: 0;
 	border: 1px solid @mbl-round-rect-border-color;
+	border-bottom-left-radius: 8px;
+	border-top-left-radius: 8px;
+	border-top-right-radius: 8px;
+	border-bottom-right-radius: 8px;
 	border-radius: 8px;
 	.mblAccordionTitle:first-child {
 		border-top-left-radius: 8px;

--- a/mobile/themes/common/IconMenu.less
+++ b/mobile/themes/common/IconMenu.less
@@ -2,6 +2,10 @@
 .mblIconMenu {
 	width: 100%;
 	height: 100%;
+	border-bottom-left-radius: @mbl-icon-menu-border-radius;
+	border-top-left-radius: @mbl-icon-menu-border-radius;
+	border-top-right-radius: @mbl-icon-menu-border-radius;
+	border-bottom-right-radius: @mbl-icon-menu-border-radius;
 	border-radius: @mbl-icon-menu-border-radius;
 	text-align: center;
 	.tap-highlight-color(rgba(255, 255, 255, 0));

--- a/mobile/themes/common/PageIndicator.less
+++ b/mobile/themes/common/PageIndicator.less
@@ -16,6 +16,10 @@
 	height: 6px;
 	font-size: 1px;
 	background-color: #949294;
+	border-bottom-left-radius: 3px;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	border-bottom-right-radius: 3px;
 	border-radius: 3px;
 }
 .mblPageIndicatorDotSelected {

--- a/mobile/themes/common/ProgressIndicator.less
+++ b/mobile/themes/common/ProgressIndicator.less
@@ -31,6 +31,10 @@
 	overflow: hidden;
 	.transform-origin(0 2px);
 	background-color: #c0c0c0;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }
 .mblProg0 {

--- a/mobile/themes/common/RadioButton.less
+++ b/mobile/themes/common/RadioButton.less
@@ -6,6 +6,10 @@
 	height: 1em;
 	border-style: outset;
 	border-width: 1px;
+	border-bottom-left-radius: 0.5em;
+	border-top-left-radius: 0.5em;
+	border-top-right-radius: 0.5em;
+	border-bottom-right-radius: 0.5em;
 	border-radius: 0.5em;
 	.mbl-button-background-image();
 	font: inherit;

--- a/mobile/themes/common/RoundRect.less
+++ b/mobile/themes/common/RoundRect.less
@@ -3,6 +3,10 @@
 	margin: 7px 9px 16px;
 	padding: 8px;
 	border: 1px solid @mbl-round-rect-border-color;
+	border-bottom-left-radius: @mbl-round-rect-border-radius;
+	border-top-left-radius: @mbl-round-rect-border-radius;
+	border-top-right-radius: @mbl-round-rect-border-radius;
+	border-bottom-right-radius: @mbl-round-rect-border-radius;
 	border-radius: @mbl-round-rect-border-radius;
 	background-color: @mbl-round-rect-background-color;
 	.mblRoundRect-styles;

--- a/mobile/themes/common/RoundRectList.less
+++ b/mobile/themes/common/RoundRectList.less
@@ -3,6 +3,10 @@
 	margin: 7px 9px 16px;
 	padding: 0;
 	border: 1px solid @mbl-round-rect-border-color;
+	border-bottom-left-radius: @mbl-round-rect-border-radius;
+	border-top-left-radius: @mbl-round-rect-border-radius;
+	border-top-right-radius: @mbl-round-rect-border-radius;
+	border-bottom-right-radius: @mbl-round-rect-border-radius;
 	border-radius: @mbl-round-rect-border-radius;
 	background-color: @mbl-round-rect-background-color;
 	.mblListItem:first-child,

--- a/mobile/themes/common/SimpleDialog.less
+++ b/mobile/themes/common/SimpleDialog.less
@@ -8,6 +8,10 @@
 	.mblSimpleDialog-styles;
 }
 .mblSimpleDialogDecoration {
+	border-bottom-left-radius: @mbl-simple-dialog-border-radius;
+	border-top-left-radius: @mbl-simple-dialog-border-radius;
+	border-top-right-radius: @mbl-simple-dialog-border-radius;
+	border-bottom-right-radius: @mbl-simple-dialog-border-radius;
 	border-radius: @mbl-simple-dialog-border-radius;
 	.mblSimpleDialogDecoration-styles;
 }

--- a/mobile/themes/common/Slider.less
+++ b/mobile/themes/common/Slider.less
@@ -3,6 +3,10 @@
 	margin: 15px; // 1/2 handle width for hanging off the ends of the bar
 	border-style: inset;
 	border-width: 1px;
+	border-bottom-left-radius: @mbl-slider-bar-border-radius;
+	border-top-left-radius: @mbl-slider-bar-border-radius;
+	border-top-right-radius: @mbl-slider-bar-border-radius;
+	border-bottom-right-radius: @mbl-slider-bar-border-radius;
 	border-radius: @mbl-slider-bar-border-radius;
 	.mbl-switch-bg-right-background-image();
 	.user-select(none); // prevent selection
@@ -30,6 +34,10 @@
 	}
 }
 .mblSliderProgressBar {
+	border-bottom-left-radius: @mbl-slider-bar-border-radius;
+	border-top-left-radius: @mbl-slider-bar-border-radius;
+	border-top-right-radius: @mbl-slider-bar-border-radius;
+	border-bottom-right-radius: @mbl-slider-bar-border-radius;
 	border-radius: @mbl-slider-bar-border-radius;
 	.mbl-switch-bg-left-background-image();
 }
@@ -39,6 +47,10 @@
 	height: 18px;
 	border-style: outset;
 	border-width: 1px;
+	border-bottom-left-radius: @mbl-slider-bar-border-radius;
+	border-top-left-radius: @mbl-slider-bar-border-radius;
+	border-top-right-radius: @mbl-slider-bar-border-radius;
+	border-bottom-right-radius: @mbl-slider-bar-border-radius;
 	border-radius: @mbl-slider-knob-border-radius;
 	.mbl-switch-knob-background-image();
 	.mblSliderHandle-styles;

--- a/mobile/themes/common/SpinWheel.less
+++ b/mobile/themes/common/SpinWheel.less
@@ -7,6 +7,10 @@
 	border-left: solid 3px #000000;
 	border-right: solid 3px #000000;
 	color: #000000;
+	border-bottom-left-radius: 3px;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	border-bottom-right-radius: 3px;
 	border-radius: 3px;
 }
 

--- a/mobile/themes/common/Switch.less
+++ b/mobile/themes/common/Switch.less
@@ -83,6 +83,10 @@
 		left: -53px;
 	}
 	.mblSwitchBg {
+		border-bottom-left-radius: @mbl-switch-square-border-radius;
+		border-top-left-radius: @mbl-switch-square-border-radius;
+		border-top-right-radius: @mbl-switch-square-border-radius;
+		border-bottom-right-radius: @mbl-switch-square-border-radius;
 		border-radius: @mbl-switch-square-border-radius;
 	}
 	.mblSwitchBgRight {
@@ -91,6 +95,10 @@
 	.mblSwitchKnob {
 		left: 53px;
 		width: 41px;
+		border-bottom-left-radius: @mbl-switch-square-border-radius;
+		border-top-left-radius: @mbl-switch-square-border-radius;
+		border-top-right-radius: @mbl-switch-square-border-radius;
+		border-bottom-right-radius: @mbl-switch-square-border-radius;
 		border-radius: @mbl-switch-square-border-radius;
 	}
 	.mblSwitchText {
@@ -112,6 +120,10 @@
 	}
 	.mblSwitchBg {
 		width: 77px;
+		border-bottom-left-radius: 14px;
+		border-top-left-radius: 14px;
+		border-top-right-radius: 14px;
+		border-bottom-right-radius: 14px;
 		border-radius: 14px;
 	}
 	.mblSwitchBgRight {
@@ -120,6 +132,10 @@
 	.mblSwitchKnob {
 		left: 50px;
 		width: 27px;
+		border-bottom-left-radius: 13px;
+		border-top-left-radius: 13px;
+		border-top-right-radius: 13px;
+		border-bottom-right-radius: 13px;
 		border-radius: 13px;
 	}
 	.mblSwitchText {
@@ -140,6 +156,10 @@
 		left: -51px;
 	}
 	.mblSwitchBg {
+		border-bottom-left-radius: 14px;
+		border-top-left-radius: 14px;
+		border-top-right-radius: 14px;
+		border-bottom-right-radius: 14px;
 		border-radius: 14px;
 	}
 	.mblSwitchBgRight {
@@ -148,6 +168,10 @@
 	.mblSwitchKnob {
 		left: 51px;
 		width: 43px;
+		border-bottom-left-radius: 13px;
+		border-top-left-radius: 13px;
+		border-top-right-radius: 13px;
+		border-bottom-right-radius: 13px;
 		border-radius: 13px;
 	}
 	.mblSwitchText {
@@ -169,6 +193,10 @@
 	}
 	.mblSwitchBg {
 		width: 77px;
+		border-bottom-left-radius: "5px 14px";
+		border-top-left-radius: "5px 14px";
+		border-top-right-radius: "5px 14px";
+		border-bottom-right-radius: "5px 14px";
 		border-radius: ~"5px/14px";
 	}
 	.mblSwitchBgRight {
@@ -177,6 +205,10 @@
 	.mblSwitchKnob {
 		left: 50px;
 		width: 27px;
+		border-bottom-left-radius: "5px 13px";
+		border-top-left-radius: "5px 13px";
+		border-top-right-radius: "5px 13px";
+		border-bottom-right-radius: "5px 13px";
 		border-radius: ~"5px/13px";
 	}
 	.mblSwitchText {
@@ -197,6 +229,10 @@
 		left: -51px;
 	}
 	.mblSwitchBg {
+		border-bottom-left-radius: "5px 14px";
+		border-top-left-radius: "5px 14px";
+		border-top-right-radius: "5px 14px";
+		border-bottom-right-radius: "5px 14px";
 		border-radius: ~"5px/14px";
 	}
 	.mblSwitchBgRight {
@@ -205,6 +241,10 @@
 	.mblSwitchKnob {
 		left: 51px;
 		width: 43px;
+		border-bottom-left-radius: "5px 13px";
+		border-top-left-radius: "5px 13px";
+		border-top-right-radius: "5px 13px";
+		border-bottom-right-radius: "5px 13px";
 		border-radius: ~"5px/13px";
 	}
 	.mblSwitchText {

--- a/mobile/themes/common/TabBar.less
+++ b/mobile/themes/common/TabBar.less
@@ -65,6 +65,10 @@
 		.mblTabBarTabBarButtonLabel-styles;
 	}
 	.mblTabBarButtonSelected {
+		border-bottom-left-radius: 3px;
+		border-top-left-radius: 3px;
+		border-top-right-radius: 3px;
+		border-bottom-right-radius: 3px;
 		border-radius: 3px;
 		.mblTabBarTabBarButtonSelected-styles;
 	}

--- a/mobile/themes/common/ToolBarButton.less
+++ b/mobile/themes/common/ToolBarButton.less
@@ -63,6 +63,10 @@
 	display: inline-block;
 	position: relative;
 	overflow: hidden;
+	border-bottom-left-radius: @mbl-tool-bar-button-body-border-radius;
+	border-top-left-radius: @mbl-tool-bar-button-body-border-radius;
+	border-top-right-radius: @mbl-tool-bar-button-body-border-radius;
+	border-bottom-right-radius: @mbl-tool-bar-button-body-border-radius;
 	border-radius: @mbl-tool-bar-button-body-border-radius;
 	.mblToolBarButtonBody-styles;
 }

--- a/mobile/themes/common/domButtons/DomButtonBlackCircleCross.css
+++ b/mobile/themes/common/domButtons/DomButtonBlackCircleCross.css
@@ -11,6 +11,10 @@
   width: 23px;
   height: 23px;
   background-color: white;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -22,6 +26,10 @@
   width: 19px;
   height: 19px;
   background-color: black;
+  border-bottom-left-radius: 10px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  border-bottom-right-radius: 10px;
   border-radius: 10px;
 }
 .mblDomButtonBlackCircleCross > div > div > div {
@@ -36,6 +44,10 @@
   background-color: white;
   -webkit-transform: rotate(45deg);
   transform: rotate(45deg);
+  border-bottom-left-radius: 1px;
+  border-top-left-radius: 1px;
+  border-top-right-radius: 1px;
+  border-bottom-right-radius: 1px;
   border-radius: 1px;
 }
 .mblDomButtonBlackCircleCross > div > div > div > div {
@@ -47,5 +59,9 @@
   margin: 0px;
   font-size: 1px;
   background-color: white;
+  border-bottom-left-radius: 1px;
+  border-top-left-radius: 1px;
+  border-top-right-radius: 1px;
+  border-bottom-right-radius: 1px;
   border-radius: 1px;
 }

--- a/mobile/themes/common/domButtons/DomButtonBlackCircleCross.less
+++ b/mobile/themes/common/domButtons/DomButtonBlackCircleCross.less
@@ -12,6 +12,10 @@
 	width: 23px;
 	height: 23px;
 	background-color: white;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 }
@@ -22,6 +26,10 @@
 	width: 19px;
 	height: 19px;
 	background-color: black;
+	border-bottom-left-radius: 10px;
+	border-top-left-radius: 10px;
+	border-top-right-radius: 10px;
+	border-bottom-right-radius: 10px;
 	border-radius: 10px;
 }
 .mblDomButtonBlackCircleCross > div > div > div {
@@ -35,6 +43,10 @@
 	border-style: none;
 	background-color: white;
 	.transform(rotate(45deg));
+	border-bottom-left-radius: 1px;
+	border-top-left-radius: 1px;
+	border-top-right-radius: 1px;
+	border-bottom-right-radius: 1px;
 	border-radius: 1px;
 }
 .mblDomButtonBlackCircleCross > div > div > div > div {
@@ -46,5 +58,9 @@
 	margin: 0px;
 	font-size: 1px;
 	background-color: white;
+	border-bottom-left-radius: 1px;
+	border-top-left-radius: 1px;
+	border-top-right-radius: 1px;
+	border-bottom-right-radius: 1px;
 	border-radius: 1px;
 }

--- a/mobile/themes/common/domButtons/DomButtonBlueBadge.css
+++ b/mobile/themes/common/domButtons/DomButtonBlueBadge.css
@@ -16,6 +16,10 @@
   right: 2px;
   color: white;
   border: 2px solid white;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   text-align: center;
   background: -webkit-gradient(linear, left top, left bottom, from(#6ba2e7), to(#216dd6), color-stop(0.5, #4282de), color-stop(0.5, #216dd6));

--- a/mobile/themes/common/domButtons/DomButtonBlueBadge.less
+++ b/mobile/themes/common/domButtons/DomButtonBlueBadge.less
@@ -17,6 +17,10 @@
 	right: 2px;
 	color: white;
 	border: 2px solid white;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	text-align: center;
 	.background-linear-gradient-top-bottom-2-stops(#6ba2e7, #216dd6, 0.5, #4282de, 0.5, #216dd6);

--- a/mobile/themes/common/domButtons/DomButtonBlueBall.css
+++ b/mobile/themes/common/domButtons/DomButtonBlueBall.css
@@ -10,6 +10,10 @@
   left: 4px;
   width: 14px;
   height: 14px;
+  border-bottom-left-radius: 7px;
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+  border-bottom-right-radius: 7px;
   border-radius: 7px;
   background: -webkit-gradient(linear, left top, left bottom, from(#84aff4), to(#2758b3));
   background: linear-gradient(to bottom, #84aff4 0%, #2758b3 100%);

--- a/mobile/themes/common/domButtons/DomButtonBlueBall.less
+++ b/mobile/themes/common/domButtons/DomButtonBlueBall.less
@@ -11,6 +11,10 @@
 	left: 4px;
 	width: 14px;
 	height: 14px;
+	border-bottom-left-radius: 7px;
+	border-top-left-radius: 7px;
+	border-top-right-radius: 7px;
+	border-bottom-right-radius: 7px;
 	border-radius: 7px;
 	.background-linear-gradient-top-bottom(#84aff4, #2758b3);
 }

--- a/mobile/themes/common/domButtons/DomButtonBlueCircleArrow.css
+++ b/mobile/themes/common/domButtons/DomButtonBlueCircleArrow.css
@@ -11,6 +11,10 @@
   width: 22px;
   height: 22px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -21,6 +25,10 @@
   left: 2px;
   width: 18px;
   height: 18px;
+  border-bottom-left-radius: 9px;
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+  border-bottom-right-radius: 9px;
   border-radius: 9px;
   background: -webkit-gradient(linear, left top, left bottom, from(#6ba2e7), to(#216dd6), color-stop(0.5, #4282de), color-stop(0.5, #216dd6));
   background: linear-gradient(to bottom, #6ba2e7 0%, #4282de 50%, #216dd6 50%, #216dd6 100%);

--- a/mobile/themes/common/domButtons/DomButtonBlueCircleArrow.less
+++ b/mobile/themes/common/domButtons/DomButtonBlueCircleArrow.less
@@ -13,6 +13,10 @@
 	width: 22px;
 	height: 22px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 }
@@ -22,6 +26,10 @@
 	left: 2px;
 	width: 18px;
 	height: 18px;
+	border-bottom-left-radius: 9px;
+	border-top-left-radius: 9px;
+	border-top-right-radius: 9px;
+	border-bottom-right-radius: 9px;
 	border-radius: 9px;
 	.background-linear-gradient-top-bottom-2-stops(#6ba2e7, #216dd6, 0.5, #4282de, 0.5, #216dd6);
 }

--- a/mobile/themes/common/domButtons/DomButtonBlueCircleMinus.css
+++ b/mobile/themes/common/domButtons/DomButtonBlueCircleMinus.css
@@ -11,6 +11,10 @@
   width: 22px;
   height: 22px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -21,6 +25,10 @@
   left: 2px;
   width: 18px;
   height: 18px;
+  border-bottom-left-radius: 9px;
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+  border-bottom-right-radius: 9px;
   border-radius: 9px;
   background: -webkit-gradient(linear, left top, left bottom, from(#6ba2e7), to(#216dd6), color-stop(0.5, #4282de), color-stop(0.5, #216dd6));
   background: linear-gradient(to bottom, #6ba2e7 0%, #4282de 50%, #216dd6 50%, #216dd6 100%);

--- a/mobile/themes/common/domButtons/DomButtonBlueCircleMinus.less
+++ b/mobile/themes/common/domButtons/DomButtonBlueCircleMinus.less
@@ -13,6 +13,10 @@
 	width: 22px;
 	height: 22px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 }
@@ -22,6 +26,10 @@
 	left: 2px;
 	width: 18px;
 	height: 18px;
+	border-bottom-left-radius: 9px;
+	border-top-left-radius: 9px;
+	border-top-right-radius: 9px;
+	border-bottom-right-radius: 9px;
 	border-radius: 9px;
 	.background-linear-gradient-top-bottom-2-stops(#6ba2e7, #216dd6, 0.5, #4282de, 0.5, #216dd6);
 }

--- a/mobile/themes/common/domButtons/DomButtonBlueCirclePlus.css
+++ b/mobile/themes/common/domButtons/DomButtonBlueCirclePlus.css
@@ -11,6 +11,10 @@
   width: 22px;
   height: 22px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -21,6 +25,10 @@
   left: 2px;
   width: 18px;
   height: 18px;
+  border-bottom-left-radius: 9px;
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+  border-bottom-right-radius: 9px;
   border-radius: 9px;
   background: -webkit-gradient(linear, left top, left bottom, from(#6ba2e7), to(#216dd6), color-stop(0.5, #4282de), color-stop(0.5, #216dd6));
   background: linear-gradient(to bottom, #6ba2e7 0%, #4282de 50%, #216dd6 50%, #216dd6 100%);

--- a/mobile/themes/common/domButtons/DomButtonBlueCirclePlus.less
+++ b/mobile/themes/common/domButtons/DomButtonBlueCirclePlus.less
@@ -13,6 +13,10 @@
 	width: 22px;
 	height: 22px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 }
@@ -22,6 +26,10 @@
 	left: 2px;
 	width: 18px;
 	height: 18px;
+	border-bottom-left-radius: 9px;
+	border-top-left-radius: 9px;
+	border-top-right-radius: 9px;
+	border-bottom-right-radius: 9px;
 	border-radius: 9px;
 	.background-linear-gradient-top-bottom-2-stops(#6ba2e7, #216dd6, 0.5, #4282de, 0.5, #216dd6);
 }

--- a/mobile/themes/common/domButtons/DomButtonCheckboxOff.css
+++ b/mobile/themes/common/domButtons/DomButtonCheckboxOff.css
@@ -7,6 +7,10 @@
   border-style: outset;
   border-color: #a5a2a5;
   color: white;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   background-color: #d6d3d6;
   background: -webkit-gradient(linear, left top, left bottom, from(#eff3ef), to(#bdbebd));
@@ -22,6 +26,10 @@
   font-size: 1px;
   background-color: #bdbabd;
   border-bottom: 1px solid #8c8e8c;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   -webkit-transform: rotate(50deg);
   transform: rotate(50deg);
@@ -37,6 +45,10 @@
   background-color: #bdbabd;
   border-bottom: none;
   border-top: 1px solid #8c8e8c;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   -webkit-transform: rotate(-100deg);
   transform: rotate(-100deg);

--- a/mobile/themes/common/domButtons/DomButtonCheckboxOff.less
+++ b/mobile/themes/common/domButtons/DomButtonCheckboxOff.less
@@ -8,6 +8,10 @@
 	border-style: outset;
 	border-color: #a5a2a5;
 	color: white;
+	border-bottom-left-radius: 3px;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	border-bottom-right-radius: 3px;
 	border-radius: 3px;
 	background-color: #d6d3d6;
 	.background-linear-gradient-top-bottom(#eff3ef, #bdbebd);
@@ -22,6 +26,10 @@
 	font-size: 1px;
 	background-color: #bdbabd;
 	border-bottom: 1px solid #8c8e8c;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 	.transform(rotate(50deg));
 }
@@ -36,6 +44,10 @@
 	background-color: #bdbabd;
 	border-bottom: none;
 	border-top: 1px solid #8c8e8c;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 	.transform(rotate(-100deg));
 }

--- a/mobile/themes/common/domButtons/DomButtonCheckboxOn.css
+++ b/mobile/themes/common/domButtons/DomButtonCheckboxOn.css
@@ -7,6 +7,10 @@
   border-style: outset;
   border-color: #a5a2a5;
   color: white;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   background-color: #d6d3d6;
   background: -webkit-gradient(linear, left top, left bottom, from(#eff3ef), to(#bdbebd));
@@ -22,6 +26,10 @@
   font-size: 1px;
   background-color: #00cf00;
   border-top: 1px solid #4a5a71;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   -webkit-transform: rotate(50deg);
   transform: rotate(50deg);
@@ -37,6 +45,10 @@
   background-color: #00cf00;
   border-top: none;
   border-bottom: 1px solid #4a5a71;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   -webkit-transform: rotate(-100deg);
   transform: rotate(-100deg);

--- a/mobile/themes/common/domButtons/DomButtonCheckboxOn.less
+++ b/mobile/themes/common/domButtons/DomButtonCheckboxOn.less
@@ -8,6 +8,10 @@
 	border-style: outset;
 	border-color: #a5a2a5;
 	color: white;
+	border-bottom-left-radius: 3px;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	border-bottom-right-radius: 3px;
 	border-radius: 3px;
 	background-color: #d6d3d6;
 	.background-linear-gradient-top-bottom(#eff3ef, #bdbebd);
@@ -22,6 +26,10 @@
 	font-size: 1px;
 	background-color: #00cf00;
 	border-top: 1px solid #4a5a71;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 	.transform(rotate(50deg));
 }
@@ -36,6 +44,10 @@
 	background-color: #00cf00;
 	border-top: none;
 	border-bottom: 1px solid #4a5a71;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 	.transform(rotate(-100deg));
 }

--- a/mobile/themes/common/domButtons/DomButtonColorButtons.css
+++ b/mobile/themes/common/domButtons/DomButtonColorButtons.css
@@ -23,6 +23,10 @@
   border-width: 1px 1px 1px 0px;
   border-style: outset;
   color: white;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblDomButtonBlueMinus > div,

--- a/mobile/themes/common/domButtons/DomButtonColorButtons.less
+++ b/mobile/themes/common/domButtons/DomButtonColorButtons.less
@@ -15,6 +15,10 @@
 	border-width: 1px 1px 1px 0px;
 	border-style: outset;
 	color: white;
+	border-bottom-left-radius: 3px;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	border-bottom-right-radius: 3px;
 	border-radius: 3px;
 }
 .mblDomButtonBlueMinus > div, .mblDomButtonBluePlus > div {

--- a/mobile/themes/common/domButtons/DomButtonGrayCross.css
+++ b/mobile/themes/common/domButtons/DomButtonGrayCross.css
@@ -17,6 +17,10 @@
   -webkit-transform: rotate(45deg);
   transform: rotate(45deg);
   -moz-transform: rotate(45deg);
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblDomButtonGrayCross > div > div {
@@ -29,5 +33,9 @@
   font-size: 1px;
   border: 1px solid #0d1721;
   background-color: #6c6e6d;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }

--- a/mobile/themes/common/domButtons/DomButtonGrayCross.less
+++ b/mobile/themes/common/domButtons/DomButtonGrayCross.less
@@ -17,6 +17,10 @@
 	background-color: #6c6e6d;
 	.transform(rotate(45deg));
 	-moz-transform: rotate(45deg);
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }
 .mblDomButtonGrayCross > div > div {
@@ -29,5 +33,9 @@
 	font-size: 1px;
 	border: 1px solid #0d1721;
 	background-color: #6c6e6d;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }

--- a/mobile/themes/common/domButtons/DomButtonGrayMinus.css
+++ b/mobile/themes/common/domButtons/DomButtonGrayMinus.css
@@ -16,5 +16,9 @@
   font-size: 1px;
   background-color: #848684;
   border-top: 1px solid #525152;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }

--- a/mobile/themes/common/domButtons/DomButtonGrayMinus.less
+++ b/mobile/themes/common/domButtons/DomButtonGrayMinus.less
@@ -15,5 +15,9 @@
 	font-size: 1px;
 	background-color: #848684;
 	border-top: 1px solid #525152;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }

--- a/mobile/themes/common/domButtons/DomButtonGrayPlus.css
+++ b/mobile/themes/common/domButtons/DomButtonGrayPlus.css
@@ -16,6 +16,10 @@
   font-size: 1px;
   background-color: #848684;
   border-top: 1px solid #525152;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblDomButtonGrayPlus > div > div {
@@ -31,5 +35,9 @@
   background-color: #848684;
   border-top: 1px solid #525152;
   border-left: 1px solid #808080;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }

--- a/mobile/themes/common/domButtons/DomButtonGrayPlus.less
+++ b/mobile/themes/common/domButtons/DomButtonGrayPlus.less
@@ -15,6 +15,10 @@
 	font-size: 1px;
 	background-color: #848684;
 	border-top: 1px solid #525152;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }
 .mblDomButtonGrayPlus > div > div { /* vert line */
@@ -28,5 +32,9 @@
 	background-color: #848684;
 	border-top: 1px solid #525152;
 	border-left: 1px solid #808080;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }

--- a/mobile/themes/common/domButtons/DomButtonGrayRoundRect.css
+++ b/mobile/themes/common/domButtons/DomButtonGrayRoundRect.css
@@ -14,6 +14,10 @@
   color: white;
   font-family: Helvetica;
   font-size: 12px;
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
   border-radius: 4px;
   background-color: #949ba5;
   text-align: center;

--- a/mobile/themes/common/domButtons/DomButtonGrayRoundRect.less
+++ b/mobile/themes/common/domButtons/DomButtonGrayRoundRect.less
@@ -15,6 +15,10 @@
 	color: white;
 	font-family: Helvetica;
 	font-size: 12px;
+	border-bottom-left-radius: 4px;
+	border-top-left-radius: 4px;
+	border-top-right-radius: 4px;
+	border-bottom-right-radius: 4px;
 	border-radius: 4px;
 	background-color: #949ba5;
 	text-align: center;

--- a/mobile/themes/common/domButtons/DomButtonGreenBadge.css
+++ b/mobile/themes/common/domButtons/DomButtonGreenBadge.css
@@ -16,6 +16,10 @@
   right: 2px;
   color: white;
   border: 2px solid white;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   text-align: center;
   background: -webkit-gradient(linear, left top, left bottom, from(#7be75a), to(#398c08), color-stop(0.5, #6bc642), color-stop(0.5, #4aad21));

--- a/mobile/themes/common/domButtons/DomButtonGreenBadge.less
+++ b/mobile/themes/common/domButtons/DomButtonGreenBadge.less
@@ -17,6 +17,10 @@
 	right: 2px;
 	color: white;
 	border: 2px solid white;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	text-align: center;
 	.background-linear-gradient-top-bottom-2-stops(#7be75a, #398c08, 0.5, #6bc642, 0.5, #4aad21);

--- a/mobile/themes/common/domButtons/DomButtonGreenBall.css
+++ b/mobile/themes/common/domButtons/DomButtonGreenBall.css
@@ -10,6 +10,10 @@
   left: 4px;
   width: 14px;
   height: 14px;
+  border-bottom-left-radius: 7px;
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+  border-bottom-right-radius: 7px;
   border-radius: 7px;
   background: -webkit-gradient(linear, left top, left bottom, from(#59e738), to(#0aa908));
   background: linear-gradient(to bottom, #59e738 0%, #0aa908 100%);

--- a/mobile/themes/common/domButtons/DomButtonGreenBall.less
+++ b/mobile/themes/common/domButtons/DomButtonGreenBall.less
@@ -11,6 +11,10 @@
 	left: 4px;
 	width: 14px;
 	height: 14px;
+	border-bottom-left-radius: 7px;
+	border-top-left-radius: 7px;
+	border-top-right-radius: 7px;
+	border-bottom-right-radius: 7px;
 	border-radius: 7px;
 	.background-linear-gradient-top-bottom(#59e738, #0aa908);
 }

--- a/mobile/themes/common/domButtons/DomButtonGreenCircleArrow.css
+++ b/mobile/themes/common/domButtons/DomButtonGreenCircleArrow.css
@@ -11,6 +11,10 @@
   width: 22px;
   height: 22px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -21,6 +25,10 @@
   left: 2px;
   width: 18px;
   height: 18px;
+  border-bottom-left-radius: 9px;
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+  border-bottom-right-radius: 9px;
   border-radius: 9px;
   background: -webkit-gradient(linear, left top, left bottom, from(#7be75a), to(#398c08), color-stop(0.5, #6bc642), color-stop(0.5, #4aad21));
   background: linear-gradient(to bottom, #7be75a 0%, #6bc642 50%, #4aad21 50%, #398c08 100%);

--- a/mobile/themes/common/domButtons/DomButtonGreenCircleArrow.less
+++ b/mobile/themes/common/domButtons/DomButtonGreenCircleArrow.less
@@ -13,6 +13,10 @@
 	width: 22px;
 	height: 22px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 }
@@ -22,6 +26,10 @@
 	left: 2px;
 	width: 18px;
 	height: 18px;
+	border-bottom-left-radius: 9px;
+	border-top-left-radius: 9px;
+	border-top-right-radius: 9px;
+	border-bottom-right-radius: 9px;
 	border-radius: 9px;
 	.background-linear-gradient-top-bottom-2-stops(#7be75a, #398c08, 0.5, #6bc642, 0.5, #4aad21);
 }

--- a/mobile/themes/common/domButtons/DomButtonGreenCircleMinus.css
+++ b/mobile/themes/common/domButtons/DomButtonGreenCircleMinus.css
@@ -11,6 +11,10 @@
   width: 22px;
   height: 22px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -21,6 +25,10 @@
   left: 2px;
   width: 18px;
   height: 18px;
+  border-bottom-left-radius: 9px;
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+  border-bottom-right-radius: 9px;
   border-radius: 9px;
   background: -webkit-gradient(linear, left top, left bottom, from(#7be75a), to(#398c08), color-stop(0.5, #6bc642), color-stop(0.5, #4aad21));
   background: linear-gradient(to bottom, #7be75a 0%, #6bc642 50%, #4aad21 50%, #398c08 100%);

--- a/mobile/themes/common/domButtons/DomButtonGreenCircleMinus.less
+++ b/mobile/themes/common/domButtons/DomButtonGreenCircleMinus.less
@@ -13,6 +13,10 @@
 	width: 22px;
 	height: 22px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 }
@@ -22,6 +26,10 @@
 	left: 2px;
 	width: 18px;
 	height: 18px;
+	border-bottom-left-radius: 9px;
+	border-top-left-radius: 9px;
+	border-top-right-radius: 9px;
+	border-bottom-right-radius: 9px;
 	border-radius: 9px;
 	.background-linear-gradient-top-bottom-2-stops(#7be75a, #398c08, 0.5, #6bc642, 0.5, #4aad21);
 }

--- a/mobile/themes/common/domButtons/DomButtonGreenCirclePlus.css
+++ b/mobile/themes/common/domButtons/DomButtonGreenCirclePlus.css
@@ -11,6 +11,10 @@
   width: 22px;
   height: 22px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -21,6 +25,10 @@
   left: 2px;
   width: 18px;
   height: 18px;
+  border-bottom-left-radius: 9px;
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+  border-bottom-right-radius: 9px;
   border-radius: 9px;
   background: -webkit-gradient(linear, left top, left bottom, from(#7be75a), to(#398c08), color-stop(0.5, #6bc642), color-stop(0.5, #4aad21));
   background: linear-gradient(to bottom, #7be75a 0%, #6bc642 50%, #4aad21 50%, #398c08 100%);

--- a/mobile/themes/common/domButtons/DomButtonGreenCirclePlus.less
+++ b/mobile/themes/common/domButtons/DomButtonGreenCirclePlus.less
@@ -13,6 +13,10 @@
 	width: 22px;
 	height: 22px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 }
@@ -22,6 +26,10 @@
 	left: 2px;
 	width: 18px;
 	height: 18px;
+	border-bottom-left-radius: 9px;
+	border-top-left-radius: 9px;
+	border-top-right-radius: 9px;
+	border-bottom-right-radius: 9px;
 	border-radius: 9px;
 	.background-linear-gradient-top-bottom-2-stops(#7be75a, #398c08, 0.5, #6bc642, 0.5, #4aad21);
 }

--- a/mobile/themes/common/domButtons/DomButtonOrangeBall.css
+++ b/mobile/themes/common/domButtons/DomButtonOrangeBall.css
@@ -10,6 +10,10 @@
   left: 4px;
   width: 14px;
   height: 14px;
+  border-bottom-left-radius: 7px;
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+  border-bottom-right-radius: 7px;
   border-radius: 7px;
   background: -webkit-gradient(linear, left top, left bottom, from(#f9e20a), to(#ff6b0a));
   background: linear-gradient(to bottom, #f9e20a 0%, #ff6b0a 100%);

--- a/mobile/themes/common/domButtons/DomButtonOrangeBall.less
+++ b/mobile/themes/common/domButtons/DomButtonOrangeBall.less
@@ -11,6 +11,10 @@
 	left: 4px;
 	width: 14px;
 	height: 14px;
+	border-bottom-left-radius: 7px;
+	border-top-left-radius: 7px;
+	border-top-right-radius: 7px;
+	border-bottom-right-radius: 7px;
 	border-radius: 7px;
 	.background-linear-gradient-top-bottom(#f9e20a, #ff6b0a);
 }

--- a/mobile/themes/common/domButtons/DomButtonRedBadge.css
+++ b/mobile/themes/common/domButtons/DomButtonRedBadge.css
@@ -16,6 +16,10 @@
   right: 2px;
   color: white;
   border: 2px solid white;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   text-align: center;
   background: -webkit-gradient(linear, left top, left bottom, from(#f5bdc0), to(#ae0001), color-stop(0.5, #e44149), color-stop(0.5, #de151f));

--- a/mobile/themes/common/domButtons/DomButtonRedBadge.less
+++ b/mobile/themes/common/domButtons/DomButtonRedBadge.less
@@ -17,6 +17,10 @@
 	right: 2px;
 	color: white;
 	border: 2px solid white;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	text-align: center;
 	.background-linear-gradient-top-bottom-2-stops(#f5bdc0, #ae0001, 0.5, #e44149, 0.5, #de151f);

--- a/mobile/themes/common/domButtons/DomButtonRedBall.css
+++ b/mobile/themes/common/domButtons/DomButtonRedBall.css
@@ -10,6 +10,10 @@
   left: 4px;
   width: 14px;
   height: 14px;
+  border-bottom-left-radius: 7px;
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+  border-bottom-right-radius: 7px;
   border-radius: 7px;
   background: -webkit-gradient(linear, left top, left bottom, from(#ec9b9d), to(#d73c3f));
   background: linear-gradient(to bottom, #ec9b9d 0%, #d73c3f 100%);

--- a/mobile/themes/common/domButtons/DomButtonRedBall.less
+++ b/mobile/themes/common/domButtons/DomButtonRedBall.less
@@ -11,6 +11,10 @@
 	left: 4px;
 	width: 14px;
 	height: 14px;
+	border-bottom-left-radius: 7px;
+	border-top-left-radius: 7px;
+	border-top-right-radius: 7px;
+	border-bottom-right-radius: 7px;
 	border-radius: 7px;
 	.background-linear-gradient-top-bottom(#ec9b9d, #d73c3f);
 }

--- a/mobile/themes/common/domButtons/DomButtonRedCircleArrow.css
+++ b/mobile/themes/common/domButtons/DomButtonRedCircleArrow.css
@@ -11,6 +11,10 @@
   width: 22px;
   height: 22px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -21,6 +25,10 @@
   left: 2px;
   width: 18px;
   height: 18px;
+  border-bottom-left-radius: 9px;
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+  border-bottom-right-radius: 9px;
   border-radius: 9px;
   background: -webkit-gradient(linear, left top, left bottom, from(#d3656d), to(#bc1320), color-stop(0.5, #c9404b), color-stop(0.5, #bc1421));
   background: linear-gradient(to bottom, #d3656d 0%, #c9404b 50%, #bc1421 50%, #bc1320 100%);

--- a/mobile/themes/common/domButtons/DomButtonRedCircleArrow.less
+++ b/mobile/themes/common/domButtons/DomButtonRedCircleArrow.less
@@ -13,6 +13,10 @@
 	width: 22px;
 	height: 22px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 }
@@ -22,6 +26,10 @@
 	left: 2px;
 	width: 18px;
 	height: 18px;
+	border-bottom-left-radius: 9px;
+	border-top-left-radius: 9px;
+	border-top-right-radius: 9px;
+	border-bottom-right-radius: 9px;
 	border-radius: 9px;
 	.background-linear-gradient-top-bottom-2-stops(#d3656d, #bc1320, 0.5, #c9404b, 0.5, #bc1421);
 }

--- a/mobile/themes/common/domButtons/DomButtonRedCircleMinus.css
+++ b/mobile/themes/common/domButtons/DomButtonRedCircleMinus.css
@@ -11,6 +11,10 @@
   width: 22px;
   height: 22px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -21,6 +25,10 @@
   left: 2px;
   width: 18px;
   height: 18px;
+  border-bottom-left-radius: 9px;
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+  border-bottom-right-radius: 9px;
   border-radius: 9px;
   background: -webkit-gradient(linear, left top, left bottom, from(#d3656d), to(#bc1320), color-stop(0.5, #c9404b), color-stop(0.5, #bc1421));
   background: linear-gradient(to bottom, #d3656d 0%, #c9404b 50%, #bc1421 50%, #bc1320 100%);

--- a/mobile/themes/common/domButtons/DomButtonRedCircleMinus.less
+++ b/mobile/themes/common/domButtons/DomButtonRedCircleMinus.less
@@ -13,6 +13,10 @@
 	width: 22px;
 	height: 22px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 }
@@ -22,6 +26,10 @@
 	left: 2px;
 	width: 18px;
 	height: 18px;
+	border-bottom-left-radius: 9px;
+	border-top-left-radius: 9px;
+	border-top-right-radius: 9px;
+	border-bottom-right-radius: 9px;
 	border-radius: 9px;
 	.background-linear-gradient-top-bottom-2-stops(#d3656d, #bc1320, 0.5, #c9404b, 0.5, #bc1421);
 }

--- a/mobile/themes/common/domButtons/DomButtonRedCirclePlus.css
+++ b/mobile/themes/common/domButtons/DomButtonRedCirclePlus.css
@@ -11,6 +11,10 @@
   width: 22px;
   height: 22px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 12px;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  border-bottom-right-radius: 12px;
   border-radius: 12px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -21,6 +25,10 @@
   left: 2px;
   width: 18px;
   height: 18px;
+  border-bottom-left-radius: 9px;
+  border-top-left-radius: 9px;
+  border-top-right-radius: 9px;
+  border-bottom-right-radius: 9px;
   border-radius: 9px;
   background: -webkit-gradient(linear, left top, left bottom, from(#d3656d), to(#bc1320), color-stop(0.5, #c9404b), color-stop(0.5, #bc1421));
   background: linear-gradient(to bottom, #d3656d 0%, #c9404b 50%, #bc1421 50%, #bc1320 100%);

--- a/mobile/themes/common/domButtons/DomButtonRedCirclePlus.less
+++ b/mobile/themes/common/domButtons/DomButtonRedCirclePlus.less
@@ -13,6 +13,10 @@
 	width: 22px;
 	height: 22px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 12px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	border-bottom-right-radius: 12px;
 	border-radius: 12px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 }
@@ -22,6 +26,10 @@
 	left: 2px;
 	width: 18px;
 	height: 18px;
+	border-bottom-left-radius: 9px;
+	border-top-left-radius: 9px;
+	border-top-right-radius: 9px;
+	border-bottom-right-radius: 9px;
 	border-radius: 9px;
 	.background-linear-gradient-top-bottom-2-stops(#d3656d, #bc1320, 0.5, #c9404b, 0.5, #bc1421);
 }

--- a/mobile/themes/common/domButtons/DomButtonRedCross.css
+++ b/mobile/themes/common/domButtons/DomButtonRedCross.css
@@ -17,6 +17,10 @@
   -webkit-transform: rotate(45deg);
   transform: rotate(45deg);
   -moz-transform: rotate(45deg);
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblDomButtonRedCross > div > div {
@@ -29,5 +33,9 @@
   font-size: 1px;
   border: 1px solid #ad3213;
   background-color: #e54d1f;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }

--- a/mobile/themes/common/domButtons/DomButtonRedCross.less
+++ b/mobile/themes/common/domButtons/DomButtonRedCross.less
@@ -17,6 +17,10 @@
 	background-color: #e54d1f;
 	.transform(rotate(45deg));
 	-moz-transform: rotate(45deg);
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }
 .mblDomButtonRedCross > div > div {
@@ -29,5 +33,9 @@
 	font-size: 1px;
 	border: 1px solid #ad3213;
 	background-color: #e54d1f;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleDownArrow.css
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleDownArrow.css
@@ -11,6 +11,10 @@
   width: 26px;
   height: 26px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -23,6 +27,10 @@
   left: 3px;
   width: 20px;
   height: 20px;
+  border-bottom-left-radius: 10px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  border-bottom-right-radius: 10px;
   border-radius: 10px;
   background: -webkit-gradient(linear, left top, left bottom, from(#979797), to(#616161));
   background: linear-gradient(to bottom, #979797 0%, #616161 100%);

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleDownArrow.less
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleDownArrow.less
@@ -12,6 +12,10 @@
 	width: 26px;
 	height: 26px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 13px;
+	border-top-left-radius: 13px;
+	border-top-right-radius: 13px;
+	border-bottom-right-radius: 13px;
 	border-radius: 13px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 	.background-linear-gradient-top-bottom(#efefef, #c2c2c2);
@@ -22,6 +26,10 @@
 	left: 3px;
 	width: 20px;
 	height: 20px;
+	border-bottom-left-radius: 10px;
+	border-top-left-radius: 10px;
+	border-top-right-radius: 10px;
+	border-bottom-right-radius: 10px;
 	border-radius: 10px;
 	.background-linear-gradient-top-bottom(#979797, #616161);
 }

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleGrayButton.css
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleGrayButton.css
@@ -11,6 +11,10 @@
   width: 26px;
   height: 26px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -24,6 +28,10 @@
   width: 12px;
   height: 12px;
   border: 1px inset #aeaeae;
+  border-bottom-left-radius: 7px;
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+  border-bottom-right-radius: 7px;
   border-radius: 7px;
   background: -webkit-gradient(linear, left top, left bottom, from(#d4d4d4), to(#bababa));
   background: linear-gradient(to bottom, #d4d4d4 0%, #bababa 100%);

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleGrayButton.less
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleGrayButton.less
@@ -12,6 +12,10 @@
 	width: 26px;
 	height: 26px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 13px;
+	border-top-left-radius: 13px;
+	border-top-right-radius: 13px;
+	border-bottom-right-radius: 13px;
 	border-radius: 13px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 	.background-linear-gradient-top-bottom(#efefef, #c2c2c2);
@@ -23,6 +27,10 @@
 	width: 12px;
 	height: 12px;
 	border: 1px inset #aeaeae;
+	border-bottom-left-radius: 7px;
+	border-top-left-radius: 7px;
+	border-top-right-radius: 7px;
+	border-bottom-right-radius: 7px;
 	border-radius: 7px;
 	.background-linear-gradient-top-bottom(#d4d4d4, #bababa);
 }

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleGreenButton.css
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleGreenButton.css
@@ -11,6 +11,10 @@
   width: 26px;
   height: 26px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -24,6 +28,10 @@
   width: 12px;
   height: 12px;
   border: 1px inset #1b991c;
+  border-bottom-left-radius: 7px;
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+  border-bottom-right-radius: 7px;
   border-radius: 7px;
   background: -webkit-gradient(radial, center center, 0, center center, 6, from(#17df25), to(#1ba51c));
   background: radial-gradient(6 at center, #17df25 0%, #1ba51c 100%);

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleGreenButton.less
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleGreenButton.less
@@ -12,6 +12,10 @@
 	width: 26px;
 	height: 26px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 13px;
+	border-top-left-radius: 13px;
+	border-top-right-radius: 13px;
+	border-bottom-right-radius: 13px;
 	border-radius: 13px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 	.background-linear-gradient-top-bottom(#efefef, #c2c2c2);
@@ -23,6 +27,10 @@
 	width: 12px;
 	height: 12px;
 	border: 1px inset #1b991c;
+	border-bottom-left-radius: 7px;
+	border-top-left-radius: 7px;
+	border-top-right-radius: 7px;
+	border-bottom-right-radius: 7px;
 	border-radius: 7px;
 	.background-radial-gradient-center(6, #17df25, #1ba51c);
 }

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleGreenPlus.css
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleGreenPlus.css
@@ -11,6 +11,10 @@
   width: 26px;
   height: 26px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleGreenPlus.less
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleGreenPlus.less
@@ -12,6 +12,10 @@
 	width: 26px;
 	height: 26px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 13px;
+	border-top-left-radius: 13px;
+	border-top-right-radius: 13px;
+	border-bottom-right-radius: 13px;
 	border-radius: 13px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 	.background-linear-gradient-top-bottom(#efefef, #c2c2c2);

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleOrangeButton.css
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleOrangeButton.css
@@ -11,6 +11,10 @@
   width: 26px;
   height: 26px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
@@ -24,6 +28,10 @@
   width: 12px;
   height: 12px;
   border: 1px inset #ca701a;
+  border-bottom-left-radius: 7px;
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+  border-bottom-right-radius: 7px;
   border-radius: 7px;
   background: -webkit-gradient(radial, center center, 0, center center, 6, from(#ff7a07), to(#e66b03));
   background: radial-gradient(6 at center, #ff7a07 0%, #e66b03 100%);

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleOrangeButton.less
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleOrangeButton.less
@@ -12,6 +12,10 @@
 	width: 26px;
 	height: 26px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 13px;
+	border-top-left-radius: 13px;
+	border-top-right-radius: 13px;
+	border-bottom-right-radius: 13px;
 	border-radius: 13px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 	.background-linear-gradient-top-bottom(#efefef, #c2c2c2);
@@ -23,6 +27,10 @@
 	width: 12px;
 	height: 12px;
 	border: 1px inset #ca701a;
+	border-bottom-left-radius: 7px;
+	border-top-left-radius: 7px;
+	border-top-right-radius: 7px;
+	border-bottom-right-radius: 7px;
 	border-radius: 7px;
 	.background-radial-gradient-center(6, #ff7a07, #e66b03);
 }

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleRedCross.css
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleRedCross.css
@@ -11,6 +11,10 @@
   width: 26px;
   height: 26px;
   border: 1px solid #b5b6b5;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
   -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.5);

--- a/mobile/themes/common/domButtons/DomButtonSilverCircleRedCross.less
+++ b/mobile/themes/common/domButtons/DomButtonSilverCircleRedCross.less
@@ -12,6 +12,10 @@
 	width: 26px;
 	height: 26px;
 	border: 1px solid #b5b6b5;
+	border-bottom-left-radius: 13px;
+	border-top-left-radius: 13px;
+	border-top-right-radius: 13px;
+	border-bottom-right-radius: 13px;
 	border-radius: 13px;
 	.box-shadow(0px 1px 2px rgba(0, 0, 0, 0.5));
 	.background-linear-gradient-top-bottom(#efefef, #c2c2c2);

--- a/mobile/themes/common/domButtons/DomButtonWhiteCross.css
+++ b/mobile/themes/common/domButtons/DomButtonWhiteCross.css
@@ -17,6 +17,10 @@
   -webkit-transform: rotate(45deg);
   transform: rotate(45deg);
   -moz-transform: rotate(45deg);
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblDomButtonWhiteCross > div > div {
@@ -29,5 +33,9 @@
   font-size: 1px;
   border: 1px solid #808080;
   background-color: #ffffff;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }

--- a/mobile/themes/common/domButtons/DomButtonWhiteCross.less
+++ b/mobile/themes/common/domButtons/DomButtonWhiteCross.less
@@ -17,6 +17,10 @@
 	background-color: #ffffff;
 	.transform(rotate(45deg));
 	-moz-transform: rotate(45deg);
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }
 .mblDomButtonWhiteCross > div > div {
@@ -29,5 +33,9 @@
 	font-size: 1px;
 	border: 1px solid #808080;
 	background-color: #ffffff;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }

--- a/mobile/themes/custom/Accordion.css
+++ b/mobile/themes/custom/Accordion.css
@@ -8,6 +8,10 @@
   margin: 7px 9px 16px 9px;
   padding: 0;
   border: 1px solid #c0c0c0;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
 }
 .mblAccordionRoundRect .mblAccordionTitle:first-child {

--- a/mobile/themes/custom/IconMenu.css
+++ b/mobile/themes/custom/IconMenu.css
@@ -2,6 +2,10 @@
 .mblIconMenu {
   width: 100%;
   height: 100%;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);

--- a/mobile/themes/custom/PageIndicator.css
+++ b/mobile/themes/custom/PageIndicator.css
@@ -16,6 +16,10 @@
   height: 6px;
   font-size: 1px;
   background-color: #949294;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblPageIndicatorDotSelected {

--- a/mobile/themes/custom/ProgressIndicator.css
+++ b/mobile/themes/custom/ProgressIndicator.css
@@ -33,6 +33,10 @@
   -webkit-transform-origin: 0 2px;
   transform-origin: 0 2px;
   background-color: #c0c0c0;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblProg0 {

--- a/mobile/themes/custom/RadioButton.css
+++ b/mobile/themes/custom/RadioButton.css
@@ -6,6 +6,10 @@
   height: 1em;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 0.5em;
+  border-top-left-radius: 0.5em;
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
   border-radius: 0.5em;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#ffffff), to(#e2e2e2));
   background-image: linear-gradient(to bottom, #ffffff 0%, #e2e2e2 100%);

--- a/mobile/themes/custom/RoundRect.css
+++ b/mobile/themes/custom/RoundRect.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 8px;
   border: 1px solid #c0c0c0;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
   background-color: #ffffff;
   color: #000000;

--- a/mobile/themes/custom/RoundRectList.css
+++ b/mobile/themes/custom/RoundRectList.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 0;
   border: 1px solid #c0c0c0;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
   background-color: #ffffff;
 }

--- a/mobile/themes/custom/SearchBox.css
+++ b/mobile/themes/custom/SearchBox.css
@@ -18,6 +18,10 @@
   display: inline-block;
   vertical-align: middle;
   margin-left: 0.5em;
+  border-bottom-left-radius: 1em;
+  border-top-left-radius: 1em;
+  border-top-right-radius: 1em;
+  border-bottom-right-radius: 1em;
   border-radius: 1em;
 }
 .mblSearchBox::-webkit-search-results-decoration {

--- a/mobile/themes/custom/SimpleDialog.css
+++ b/mobile/themes/custom/SimpleDialog.css
@@ -9,6 +9,10 @@
   width: 262px;
 }
 .mblSimpleDialogDecoration {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   background-color: #ffffff;
   border: 1px solid #000000;

--- a/mobile/themes/custom/Slider.css
+++ b/mobile/themes/custom/Slider.css
@@ -3,6 +3,10 @@
   margin: 15px;
   border-style: inset;
   border-width: 1px;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#ffffff), to(#e2e2e2));
   background-image: linear-gradient(to bottom, #ffffff 0%, #e2e2e2 100%);
@@ -34,6 +38,10 @@
   left: 50%;
 }
 .mblSliderProgressBar {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#bbbbbb), to(#999999));
   background-image: linear-gradient(to bottom, #bbbbbb 0%, #999999 100%);
@@ -44,6 +52,10 @@
   height: 18px;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#e2e2e2), to(#a4a4a4));
   background-image: linear-gradient(to bottom, #e2e2e2 0%, #a4a4a4 100%);

--- a/mobile/themes/custom/SpinWheel.css
+++ b/mobile/themes/custom/SpinWheel.css
@@ -8,6 +8,10 @@
   border-left: solid 3px #000000;
   border-right: solid 3px #000000;
   color: #000000;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblSpinWheelBar {

--- a/mobile/themes/custom/Switch.css
+++ b/mobile/themes/custom/Switch.css
@@ -90,6 +90,10 @@
   left: -53px;
 }
 .mblSwSquareShape .mblSwitchBg {
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwSquareShape .mblSwitchBgRight {
@@ -98,6 +102,10 @@
 .mblSwSquareShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwSquareShape .mblSwitchText {
@@ -115,6 +123,10 @@
 }
 .mblSwRoundShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape1 .mblSwitchBgRight {
@@ -123,6 +135,10 @@
 .mblSwRoundShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape1 .mblSwitchText {
@@ -139,6 +155,10 @@
   left: -51px;
 }
 .mblSwRoundShape2 .mblSwitchBg {
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape2 .mblSwitchBgRight {
@@ -147,6 +167,10 @@
 .mblSwRoundShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape2 .mblSwitchText {
@@ -164,6 +188,10 @@
 }
 .mblSwArcShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape1 .mblSwitchBgRight {
@@ -172,6 +200,10 @@
 .mblSwArcShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape1 .mblSwitchText {
@@ -188,6 +220,10 @@
   left: -51px;
 }
 .mblSwArcShape2 .mblSwitchBg {
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape2 .mblSwitchBgRight {
@@ -196,6 +232,10 @@
 .mblSwArcShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape2 .mblSwitchText {
@@ -212,6 +252,10 @@
   left: -53px;
 }
 .mblSwDefaultShape .mblSwitchBg {
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwDefaultShape .mblSwitchBgRight {
@@ -220,6 +264,10 @@
 .mblSwDefaultShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwDefaultShape .mblSwitchText {

--- a/mobile/themes/custom/TabBar.css
+++ b/mobile/themes/custom/TabBar.css
@@ -60,6 +60,10 @@
   color: #ffffff;
 }
 .mblTabBarTabBar .mblTabBarButtonSelected {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   background-color: #404040;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#484848), to(#242424));

--- a/mobile/themes/custom/ToolBarButton.css
+++ b/mobile/themes/custom/ToolBarButton.css
@@ -38,6 +38,10 @@
   top: 5px;
   width: 20px;
   height: 19px;
+  border-bottom-left-radius: 1px;
+  border-top-left-radius: 1px;
+  border-top-right-radius: 1px;
+  border-bottom-right-radius: 1px;
   border-radius: 1px;
   -webkit-transform: scale(0.7, 1.05) rotate(45deg);
   transform: scale(0.7, 1.05) rotate(45deg);
@@ -55,6 +59,10 @@
   display: inline-block;
   position: relative;
   overflow: hidden;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   border: 1px solid #9b9b9b;
   border-bottom-color: #767676;

--- a/mobile/themes/custom/variables.less
+++ b/mobile/themes/custom/variables.less
@@ -183,6 +183,10 @@
 	text-shadow: none;
 }
 .mblToolBarButtonArrow-styles () {
+	border-bottom-left-radius: 1px;
+	border-top-left-radius: 1px;
+	border-top-right-radius: 1px;
+	border-bottom-right-radius: 1px;
 	border-radius: 1px;
   .transform(scale(0.7, 1.05) rotate(45deg));
 	border: 1px solid @lightColor12;
@@ -780,6 +784,10 @@
 @mbl-searchbox-cancel-button-color: @lightColor;
 @mbl-searchbox-cancel-button-bg-color: @lightColor13;
 .mblSearchBox-Cancel-Button-styles () {
+	border-bottom-left-radius: 1em;
+	border-top-left-radius: 1em;
+	border-top-right-radius: 1em;
+	border-bottom-right-radius: 1em;
 	border-radius: 1em;
 }
 @mbl-searchbox-results-decoration-color: @lightColor13;

--- a/mobile/themes/holodark/Accordion-compat.css
+++ b/mobile/themes/holodark/Accordion-compat.css
@@ -9,6 +9,10 @@
   border-top-style: solid;
   border-top-color: rgba(85, 85, 85, 0.9);
   border-top-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .dj_gecko .mblAccordionTitleSelected {

--- a/mobile/themes/holodark/Accordion.css
+++ b/mobile/themes/holodark/Accordion.css
@@ -8,6 +8,10 @@
   margin: 7px 9px 16px 9px;
   padding: 0;
   border: 1px solid #222222;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
 }
 .mblAccordionRoundRect .mblAccordionTitle:first-child {
@@ -36,6 +40,10 @@
   border-top-style: solid;
   border-top-color: rgba(85, 85, 85, 0.9);
   border-top-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblAccordionTitle:first-child {

--- a/mobile/themes/holodark/Button.css
+++ b/mobile/themes/holodark/Button.css
@@ -14,6 +14,10 @@
   border-top-style: solid;
   border-top-color: rgba(85, 85, 85, 0.9);
   border-top-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   height: 40px;
   color: #ffffff;
@@ -40,6 +44,10 @@
   border-top-style: solid;
   border-top-color: rgba(85, 85, 85, 0.9);
   border-top-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   background-color: #0099CC;
 }
@@ -56,6 +64,10 @@
   border-top-style: solid;
   border-top-color: rgba(85, 85, 85, 0.9);
   border-top-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   background-color: #CC0000;
 }
@@ -71,6 +83,10 @@
   border-top-style: solid;
   border-top-color: rgba(85, 85, 85, 0.9);
   border-top-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   background-color: #212121;
 }

--- a/mobile/themes/holodark/CheckBox.css
+++ b/mobile/themes/holodark/CheckBox.css
@@ -10,6 +10,10 @@
   border-top-style: solid;
   border-top-color: rgba(85, 85, 85, 0.9);
   border-top-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   font: inherit;
   cursor: pointer;

--- a/mobile/themes/holodark/IconMenu.css
+++ b/mobile/themes/holodark/IconMenu.css
@@ -2,6 +2,10 @@
 .mblIconMenu {
   width: 100%;
   height: 100%;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);

--- a/mobile/themes/holodark/PageIndicator.css
+++ b/mobile/themes/holodark/PageIndicator.css
@@ -16,6 +16,10 @@
   height: 6px;
   font-size: 1px;
   background-color: #949294;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblPageIndicatorDotSelected {

--- a/mobile/themes/holodark/ProgressIndicator.css
+++ b/mobile/themes/holodark/ProgressIndicator.css
@@ -33,6 +33,10 @@
   -webkit-transform-origin: 0 2px;
   transform-origin: 0 2px;
   background-color: #c0c0c0;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblProg0 {

--- a/mobile/themes/holodark/RadioButton.css
+++ b/mobile/themes/holodark/RadioButton.css
@@ -6,6 +6,10 @@
   height: 1em;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 0.5em;
+  border-top-left-radius: 0.5em;
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
   border-radius: 0.5em;
   background-image: none;
   background-color: #333333;
@@ -13,6 +17,10 @@
   border-top-style: solid;
   border-top-color: rgba(85, 85, 85, 0.9);
   border-top-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   font: inherit;
   cursor: pointer;
@@ -53,6 +61,10 @@
 .mblRadioButton {
   border-style: solid;
   border-width: 1px;
+  border-bottom-left-radius: 999px;
+  border-top-left-radius: 999px;
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
   border-radius: 999px;
   background-image: none;
   background-color: transparent;
@@ -73,6 +85,10 @@
   left: 0.17em;
   border-style: none;
   background-color: #61c6eb;
+  border-bottom-left-radius: 1em;
+  border-top-left-radius: 1em;
+  border-top-right-radius: 1em;
+  border-bottom-right-radius: 1em;
   border-radius: 1em;
   border-color: #61c6eb;
 }

--- a/mobile/themes/holodark/RadioButton.less
+++ b/mobile/themes/holodark/RadioButton.less
@@ -3,6 +3,10 @@
 .mblRadioButton {
   border-style: solid;
   border-width: 1px;
+  border-bottom-left-radius: 999px;
+  border-top-left-radius: 999px;
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
   border-radius: 999px;
   background-image: none;
   background-color: transparent;
@@ -22,6 +26,10 @@
     
     border-style: none;
     background-color: @holo-checkbox-tick-color;
+    border-bottom-left-radius: 1em;
+    border-top-left-radius: 1em;
+    border-top-right-radius: 1em;
+    border-bottom-right-radius: 1em;
     border-radius: 1em;
 
     .mblRadioButtonChecked-after-styles;

--- a/mobile/themes/holodark/RoundRect.css
+++ b/mobile/themes/holodark/RoundRect.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 8px;
   border: 1px solid #222222;
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
   background-color: transparent;
   color: white;

--- a/mobile/themes/holodark/RoundRectList.css
+++ b/mobile/themes/holodark/RoundRectList.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 0;
   border: 1px solid #222222;
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
   background-color: transparent;
 }

--- a/mobile/themes/holodark/SimpleDialog.css
+++ b/mobile/themes/holodark/SimpleDialog.css
@@ -18,6 +18,10 @@
   border-top-style: solid;
   border-top-width: 1px;
   border-top-color: rgba(255, 255, 255, 0.6);
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSimpleDialogContainer {

--- a/mobile/themes/holodark/Slider.css
+++ b/mobile/themes/holodark/Slider.css
@@ -3,6 +3,10 @@
   margin: 15px;
   border-style: inset;
   border-width: 1px;
+  border-bottom-left-radius: 10em;
+  border-top-left-radius: 10em;
+  border-top-right-radius: 10em;
+  border-bottom-right-radius: 10em;
   border-radius: 10em;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#bdbebd), to(#f7f3f7));
   background-image: linear-gradient(to bottom, #bdbebd 0%, #f7f3f7 100%);
@@ -33,6 +37,10 @@
   left: 50%;
 }
 .mblSliderProgressBar {
+  border-bottom-left-radius: 10em;
+  border-top-left-radius: 10em;
+  border-top-right-radius: 10em;
+  border-bottom-right-radius: 10em;
   border-radius: 10em;
   background-image: none;
 }
@@ -42,6 +50,10 @@
   height: 18px;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 10em;
+  border-top-left-radius: 10em;
+  border-top-right-radius: 10em;
+  border-bottom-right-radius: 10em;
   border-radius: 10em;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#9c9a9c), to(#848284));
   background-image: linear-gradient(to bottom, #9c9a9c 0%, #848284 100%);

--- a/mobile/themes/holodark/SpinWheel.css
+++ b/mobile/themes/holodark/SpinWheel.css
@@ -8,6 +8,10 @@
   border-left: solid 3px #000000;
   border-right: solid 3px #000000;
   color: #000000;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblSpinWheelBar {

--- a/mobile/themes/holodark/Switch.css
+++ b/mobile/themes/holodark/Switch.css
@@ -87,6 +87,10 @@
   left: -53px;
 }
 .mblSwSquareShape .mblSwitchBg {
+  border-bottom-left-radius: 0px;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
   border-radius: 0px;
 }
 .mblSwSquareShape .mblSwitchBgRight {
@@ -95,6 +99,10 @@
 .mblSwSquareShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 0px;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
   border-radius: 0px;
 }
 .mblSwSquareShape .mblSwitchText {
@@ -112,6 +120,10 @@
 }
 .mblSwRoundShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape1 .mblSwitchBgRight {
@@ -120,6 +132,10 @@
 .mblSwRoundShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape1 .mblSwitchText {
@@ -136,6 +152,10 @@
   left: -51px;
 }
 .mblSwRoundShape2 .mblSwitchBg {
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape2 .mblSwitchBgRight {
@@ -144,6 +164,10 @@
 .mblSwRoundShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape2 .mblSwitchText {
@@ -161,6 +185,10 @@
 }
 .mblSwArcShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape1 .mblSwitchBgRight {
@@ -169,6 +197,10 @@
 .mblSwArcShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape1 .mblSwitchText {
@@ -185,6 +217,10 @@
   left: -51px;
 }
 .mblSwArcShape2 .mblSwitchBg {
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape2 .mblSwitchBgRight {
@@ -193,6 +229,10 @@
 .mblSwArcShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape2 .mblSwitchText {
@@ -209,6 +249,10 @@
   left: -53px;
 }
 .mblSwDefaultShape .mblSwitchBg {
+  border-bottom-left-radius: 0px;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
   border-radius: 0px;
 }
 .mblSwDefaultShape .mblSwitchBgRight {
@@ -217,6 +261,10 @@
 .mblSwDefaultShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 0px;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  border-bottom-right-radius: 0px;
   border-radius: 0px;
 }
 .mblSwDefaultShape .mblSwitchText {

--- a/mobile/themes/holodark/TabBar.css
+++ b/mobile/themes/holodark/TabBar.css
@@ -74,6 +74,10 @@
   font-weight: bold;
 }
 .mblTabBarTabBar .mblTabBarButtonSelected {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   border-radius: 0px;
   height: 42px;

--- a/mobile/themes/holodark/TextArea.css
+++ b/mobile/themes/holodark/TextArea.css
@@ -11,6 +11,10 @@
   border-top-style: solid;
   border-top-color: rgba(85, 85, 85, 0.9);
   border-top-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   color: #ffffff;
   border-radius: 0;

--- a/mobile/themes/holodark/ToggleButton.css
+++ b/mobile/themes/holodark/ToggleButton.css
@@ -15,6 +15,10 @@
   border-top-style: solid;
   border-top-color: rgba(85, 85, 85, 0.9);
   border-top-width: 1px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
   font-size: 13px;
   color: black;

--- a/mobile/themes/holodark/ToolBarButton.css
+++ b/mobile/themes/holodark/ToolBarButton.css
@@ -38,6 +38,10 @@
   top: 5px;
   width: 20px;
   height: 19px;
+  border-bottom-left-radius: 1px;
+  border-top-left-radius: 1px;
+  border-top-right-radius: 1px;
+  border-bottom-right-radius: 1px;
   border-radius: 1px;
   -webkit-transform: scale(0.7, 1.05) rotate(45deg);
   transform: scale(0.7, 1.05) rotate(45deg);
@@ -53,6 +57,10 @@
   display: inline-block;
   position: relative;
   overflow: hidden;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   border: 1px solid #555555;
 }

--- a/mobile/themes/holodark/variables.less
+++ b/mobile/themes/holodark/variables.less
@@ -71,6 +71,10 @@
 	border-top-style: solid;
 	border-top-color: rgba(85,85,85,0.9);
 	border-top-width: 1px;
+	border-bottom-left-radius: 2px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+	border-bottom-right-radius: 2px;
 	border-radius: 2px;
 }
 
@@ -159,6 +163,10 @@
 }
 
 .mblToolBarButtonArrow-styles () {
+	border-bottom-left-radius: 1px;
+	border-top-left-radius: 1px;
+	border-top-right-radius: 1px;
+	border-bottom-right-radius: 1px;
 	border-radius: 1px;
   .transform(scale(0.7, 1.05) rotate(45deg));
 	border: 1px solid #3a4655;
@@ -702,7 +710,11 @@
   border-top-style: solid;
   border-top-width: 1px;
   border-top-color: rgba(255,255,255,0.6);
-  border-radius: 2px; 
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
+  border-radius: 2px;
 }
 .mblSimpleDialogDecoration-compat () {
 	background-color: #404040;

--- a/mobile/themes/iphone/Accordion.css
+++ b/mobile/themes/iphone/Accordion.css
@@ -8,6 +8,10 @@
   margin: 7px 9px 16px 9px;
   padding: 0;
   border: 1px solid #adaaad;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
 }
 .mblAccordionRoundRect .mblAccordionTitle:first-child {

--- a/mobile/themes/iphone/IconMenu.css
+++ b/mobile/themes/iphone/IconMenu.css
@@ -2,6 +2,10 @@
 .mblIconMenu {
   width: 100%;
   height: 100%;
+  border-bottom-left-radius: 10px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  border-bottom-right-radius: 10px;
   border-radius: 10px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);

--- a/mobile/themes/iphone/PageIndicator.css
+++ b/mobile/themes/iphone/PageIndicator.css
@@ -16,6 +16,10 @@
   height: 6px;
   font-size: 1px;
   background-color: #949294;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblPageIndicatorDotSelected {

--- a/mobile/themes/iphone/ProgressBar.css
+++ b/mobile/themes/iphone/ProgressBar.css
@@ -1,6 +1,10 @@
 /* dojox.mobile.ProgressBar */
 .mblProgressBar {
   position: relative;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   height: 9px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#a5a6a5), to(#b5b6b5), color-stop(0.5, #d6d7d6), color-stop(0.5, #ffffff), color-stop(0.9, #ffffff));
@@ -13,6 +17,10 @@
   transition-duration: 0.25s;
   height: 7px;
   border: 1px solid #5e6fa3;
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
   border-radius: 6px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#b0c0ff), to(#2f83e1), color-stop(0.6, #70b2ff), color-stop(0.6, #3470b6));
   background-image: linear-gradient(to bottom, #b0c0ff 0%, #70b2ff 60%, #3470b6 60%, #2f83e1 100%);

--- a/mobile/themes/iphone/ProgressIndicator.css
+++ b/mobile/themes/iphone/ProgressIndicator.css
@@ -33,6 +33,10 @@
   -webkit-transform-origin: 0 2px;
   transform-origin: 0 2px;
   background-color: #c0c0c0;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblProg0 {

--- a/mobile/themes/iphone/RadioButton.css
+++ b/mobile/themes/iphone/RadioButton.css
@@ -6,6 +6,10 @@
   height: 1em;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 0.5em;
+  border-top-left-radius: 0.5em;
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
   border-radius: 0.5em;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#fdfdfd), to(#cecece), color-stop(0.5, #f8f8f8), color-stop(0.5, #eeeeee));
   background-image: linear-gradient(to bottom, #fdfdfd 0%, #f8f8f8 50%, #eeeeee 50%, #cecece 100%);

--- a/mobile/themes/iphone/RoundRect.css
+++ b/mobile/themes/iphone/RoundRect.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 8px;
   border: 1px solid #adaaad;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
   background-color: #ffffff;
 }

--- a/mobile/themes/iphone/RoundRectList.css
+++ b/mobile/themes/iphone/RoundRectList.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 0;
   border: 1px solid #adaaad;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
   background-color: #ffffff;
 }

--- a/mobile/themes/iphone/SearchBox.css
+++ b/mobile/themes/iphone/SearchBox.css
@@ -18,6 +18,10 @@
   display: inline-block;
   vertical-align: middle;
   margin-left: 0.5em;
+  border-bottom-left-radius: 1em;
+  border-top-left-radius: 1em;
+  border-top-right-radius: 1em;
+  border-bottom-right-radius: 1em;
   border-radius: 1em;
 }
 .mblSearchBox::-webkit-search-results-decoration {

--- a/mobile/themes/iphone/SimpleDialog.css
+++ b/mobile/themes/iphone/SimpleDialog.css
@@ -9,6 +9,10 @@
   width: 262px;
 }
 .mblSimpleDialogDecoration {
+  border-bottom-left-radius: 10px;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  border-bottom-right-radius: 10px;
   border-radius: 10px;
   background-color: rgba(35, 50, 96, 0.85);
   background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(150, 150, 170, 0.85)), to(rgba(18, 29, 68, 0.85)), color-stop(0.15, rgba(77, 85, 119, 0.85)), color-stop(0.15, rgba(35, 50, 96, 0.85)));

--- a/mobile/themes/iphone/Slider.css
+++ b/mobile/themes/iphone/Slider.css
@@ -3,6 +3,10 @@
   margin: 15px;
   border-style: inset;
   border-width: 1px;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#cecece), to(#fdfdfd), color-stop(0.5, #eeeeee), color-stop(0.5, #f8f8f8));
   background-image: linear-gradient(to bottom, #cecece 0%, #eeeeee 50%, #f8f8f8 50%, #fdfdfd 100%);
@@ -33,6 +37,10 @@
   left: 50%;
 }
 .mblSliderProgressBar {
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#2859b1), to(#75acfb), color-stop(0.5, #3f84eb), color-stop(0.5, #4c8eee));
   background-image: linear-gradient(to bottom, #2859b1 0%, #3f84eb 50%, #4c8eee 50%, #75acfb 100%);
@@ -43,6 +51,10 @@
   height: 18px;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 10px;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#cccccc), to(#fafafa));
   background-image: linear-gradient(to bottom, #cccccc 0%, #fafafa 100%);

--- a/mobile/themes/iphone/SpinWheel.css
+++ b/mobile/themes/iphone/SpinWheel.css
@@ -8,6 +8,10 @@
   border-left: solid 3px #000000;
   border-right: solid 3px #000000;
   color: #000000;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblSpinWheelBar {

--- a/mobile/themes/iphone/Switch.css
+++ b/mobile/themes/iphone/Switch.css
@@ -92,6 +92,10 @@
   left: -53px;
 }
 .mblSwSquareShape .mblSwitchBg {
+  border-bottom-left-radius: 5px;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
   border-radius: 5px;
 }
 .mblSwSquareShape .mblSwitchBgRight {
@@ -100,6 +104,10 @@
 .mblSwSquareShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 5px;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
   border-radius: 5px;
 }
 .mblSwSquareShape .mblSwitchText {
@@ -117,6 +125,10 @@
 }
 .mblSwRoundShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape1 .mblSwitchBgRight {
@@ -125,6 +137,10 @@
 .mblSwRoundShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape1 .mblSwitchText {
@@ -141,6 +157,10 @@
   left: -51px;
 }
 .mblSwRoundShape2 .mblSwitchBg {
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape2 .mblSwitchBgRight {
@@ -149,6 +169,10 @@
 .mblSwRoundShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape2 .mblSwitchText {
@@ -166,6 +190,10 @@
 }
 .mblSwArcShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape1 .mblSwitchBgRight {
@@ -174,6 +202,10 @@
 .mblSwArcShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape1 .mblSwitchText {
@@ -190,6 +222,10 @@
   left: -51px;
 }
 .mblSwArcShape2 .mblSwitchBg {
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape2 .mblSwitchBgRight {
@@ -198,6 +234,10 @@
 .mblSwArcShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape2 .mblSwitchText {
@@ -215,6 +255,10 @@
 }
 .mblSwDefaultShape .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwDefaultShape .mblSwitchBgRight {
@@ -223,6 +267,10 @@
 .mblSwDefaultShape .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwDefaultShape .mblSwitchText {

--- a/mobile/themes/iphone/TabBar.css
+++ b/mobile/themes/iphone/TabBar.css
@@ -60,6 +60,10 @@
   color: #979797;
 }
 .mblTabBarTabBar .mblTabBarButtonSelected {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   background-color: #404040;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#484848), to(#242424), color-stop(0.5, #353535), color-stop(0.5, #242424));

--- a/mobile/themes/iphone/ToolBarButton.css
+++ b/mobile/themes/iphone/ToolBarButton.css
@@ -66,6 +66,10 @@
   display: inline-block;
   position: relative;
   overflow: hidden;
+  border-bottom-left-radius: 5px;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
   border-radius: 5px;
   border: 1px outset #9cacc0;
 }

--- a/mobile/themes/iphone/Tooltip.css
+++ b/mobile/themes/iphone/Tooltip.css
@@ -146,6 +146,8 @@
   border-top: 3px solid #4f5055;
   border-bottom: 1px solid #2d3642;
   border-left: 1px solid #2a2d47;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
   border-radius: 3px 3px 0 0;
   background-color: #889bb3;
   background-image: -webkit-gradient(linear, left top, left bottom, from(#5e6167), to(#1a1d24), color-stop(0.5, #2e322b));

--- a/mobile/themes/iphone/ValuePicker.css
+++ b/mobile/themes/iphone/ValuePicker.css
@@ -11,6 +11,10 @@
   margin: 0 3px;
   border-left: solid 2px #000000;
   border-right: solid 2px #000000;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblValuePickerSlotButton {

--- a/mobile/themes/iphone/variables.less
+++ b/mobile/themes/iphone/variables.less
@@ -504,6 +504,8 @@
 	border-top: 3px solid #4f5055;
 	border-bottom: 1px solid #2d3642;
 	border-left: 1px solid #2a2d47;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
 	border-radius: 3px 3px 0 0;
 	background-color: #889bb3;
 	.background-image-linear-gradient-top-bottom-1-stop(#5e6167, #1a1d24, 0.5, #2e322b);
@@ -725,12 +727,20 @@
 @mbl-searchbox-cancel-button-color: white;
 @mbl-searchbox-cancel-button-bg-color: #b2b2b2;
 .mblSearchBox-Cancel-Button-styles () {
+	border-bottom-left-radius: 1em;
+	border-top-left-radius: 1em;
+	border-top-right-radius: 1em;
+	border-bottom-right-radius: 1em;
 	border-radius: 1em;
 }
 @mbl-searchbox-results-decoration-color: #93989c;
 
 // ProgressBar.less
 .mblProgressBar-styles () {
+	border-bottom-left-radius: 6px;
+	border-top-left-radius: 6px;
+	border-top-right-radius: 6px;
+	border-bottom-right-radius: 6px;
 	border-radius: 6px;
 	height: 9px;
 	.background-image-linear-gradient-top-bottom-3-stops(#a5a6a5, #b5b6b5, 0.5, #d6d7d6, 0.5, #ffffff, 0.9, #ffffff);
@@ -738,6 +748,10 @@
 .mblProgressBarProgress-styles () {
 	height: 7px;
 	border:1px solid #5e6fa3;
+	border-bottom-left-radius: 6px;
+	border-top-left-radius: 6px;
+	border-top-right-radius: 6px;
+	border-bottom-right-radius: 6px;
 	border-radius: 6px;
 	.background-image-linear-gradient-top-bottom-2-stops(#b0c0ff, #2f83e1, 0.6, #70b2ff, 0.6, #3470b6);
 }
@@ -772,6 +786,10 @@
   margin: 0 3px;
   border-left: solid 2px #000000;
   border-right: solid 2px #000000;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblValuePickerSlot-input-style () {

--- a/mobile/themes/windows/Accordion.css
+++ b/mobile/themes/windows/Accordion.css
@@ -8,6 +8,10 @@
   margin: 7px 9px 16px 9px;
   padding: 0;
   border: 1px solid #cccccc;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
 }
 .mblAccordionRoundRect .mblAccordionTitle:first-child {

--- a/mobile/themes/windows/IconMenu.css
+++ b/mobile/themes/windows/IconMenu.css
@@ -2,6 +2,10 @@
 .mblIconMenu {
   width: 100%;
   height: 100%;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);

--- a/mobile/themes/windows/PageIndicator.css
+++ b/mobile/themes/windows/PageIndicator.css
@@ -16,6 +16,10 @@
   height: 6px;
   font-size: 1px;
   background-color: #949294;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblPageIndicatorDotSelected {

--- a/mobile/themes/windows/ProgressIndicator.css
+++ b/mobile/themes/windows/ProgressIndicator.css
@@ -33,6 +33,10 @@
   -webkit-transform-origin: 0 2px;
   transform-origin: 0 2px;
   background-color: #c0c0c0;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblProg0 {

--- a/mobile/themes/windows/RadioButton.css
+++ b/mobile/themes/windows/RadioButton.css
@@ -6,6 +6,10 @@
   height: 1em;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 0.5em;
+  border-top-left-radius: 0.5em;
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
   border-radius: 0.5em;
   font: inherit;
   cursor: pointer;

--- a/mobile/themes/windows/RoundRect.css
+++ b/mobile/themes/windows/RoundRect.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 8px;
   border: 1px solid #cccccc;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
   background-color: #ffffff;
   border: none;

--- a/mobile/themes/windows/RoundRectList.css
+++ b/mobile/themes/windows/RoundRectList.css
@@ -3,6 +3,10 @@
   margin: 7px 9px 16px;
   padding: 0;
   border: 1px solid #cccccc;
+  border-bottom-left-radius: 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
   border-radius: 8px;
   background-color: #ffffff;
 }

--- a/mobile/themes/windows/SimpleDialog.css
+++ b/mobile/themes/windows/SimpleDialog.css
@@ -12,6 +12,10 @@
   left: 0px !important;
 }
 .mblSimpleDialogDecoration {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   background-color: #1f1f1f;
   color: #ffffff;

--- a/mobile/themes/windows/Slider.css
+++ b/mobile/themes/windows/Slider.css
@@ -3,6 +3,10 @@
   margin: 15px;
   border-style: inset;
   border-width: 1px;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   -webkit-user-select: none;
   -ms-user-select: none;
@@ -35,6 +39,10 @@
   left: 50%;
 }
 .mblSliderProgressBar {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
 }
 .mblSliderHandle {
@@ -43,6 +51,10 @@
   height: 18px;
   border-style: outset;
   border-width: 1px;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   border: none;
   background-color: #ffffff;

--- a/mobile/themes/windows/SpinWheel.css
+++ b/mobile/themes/windows/SpinWheel.css
@@ -8,6 +8,10 @@
   border-left: solid 3px #000000;
   border-right: solid 3px #000000;
   color: #000000;
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
 }
 .mblSpinWheelBar {

--- a/mobile/themes/windows/Switch.css
+++ b/mobile/themes/windows/Switch.css
@@ -86,6 +86,10 @@
   left: -53px;
 }
 .mblSwSquareShape .mblSwitchBg {
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwSquareShape .mblSwitchBgRight {
@@ -94,6 +98,10 @@
 .mblSwSquareShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwSquareShape .mblSwitchText {
@@ -111,6 +119,10 @@
 }
 .mblSwRoundShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape1 .mblSwitchBgRight {
@@ -119,6 +131,10 @@
 .mblSwRoundShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape1 .mblSwitchText {
@@ -135,6 +151,10 @@
   left: -51px;
 }
 .mblSwRoundShape2 .mblSwitchBg {
+  border-bottom-left-radius: 14px;
+  border-top-left-radius: 14px;
+  border-top-right-radius: 14px;
+  border-bottom-right-radius: 14px;
   border-radius: 14px;
 }
 .mblSwRoundShape2 .mblSwitchBgRight {
@@ -143,6 +163,10 @@
 .mblSwRoundShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+  border-top-right-radius: 13px;
+  border-bottom-right-radius: 13px;
   border-radius: 13px;
 }
 .mblSwRoundShape2 .mblSwitchText {
@@ -160,6 +184,10 @@
 }
 .mblSwArcShape1 .mblSwitchBg {
   width: 77px;
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape1 .mblSwitchBgRight {
@@ -168,6 +196,10 @@
 .mblSwArcShape1 .mblSwitchKnob {
   left: 50px;
   width: 27px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape1 .mblSwitchText {
@@ -184,6 +216,10 @@
   left: -51px;
 }
 .mblSwArcShape2 .mblSwitchBg {
+  border-bottom-left-radius: "5px 14px";
+  border-top-left-radius: "5px 14px";
+  border-top-right-radius: "5px 14px";
+  border-bottom-right-radius: "5px 14px";
   border-radius: 5px/14px;
 }
 .mblSwArcShape2 .mblSwitchBgRight {
@@ -192,6 +228,10 @@
 .mblSwArcShape2 .mblSwitchKnob {
   left: 51px;
   width: 43px;
+  border-bottom-left-radius: "5px 13px";
+  border-top-left-radius: "5px 13px";
+  border-top-right-radius: "5px 13px";
+  border-bottom-right-radius: "5px 13px";
   border-radius: 5px/13px;
 }
 .mblSwArcShape2 .mblSwitchText {
@@ -208,6 +248,10 @@
   left: -53px;
 }
 .mblSwDefaultShape .mblSwitchBg {
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwDefaultShape .mblSwitchBgRight {
@@ -216,6 +260,10 @@
 .mblSwDefaultShape .mblSwitchKnob {
   left: 53px;
   width: 41px;
+  border-bottom-left-radius: 2px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
   border-radius: 2px;
 }
 .mblSwDefaultShape .mblSwitchText {

--- a/mobile/themes/windows/TabBar.css
+++ b/mobile/themes/windows/TabBar.css
@@ -62,6 +62,10 @@
   font-family: "Segoe WP", "Segoe UI", "HelveticaNeue", "Helvetica-Neue", "Helvetica", "BBAlpha Sans", "sans-serif";
 }
 .mblTabBarTabBar .mblTabBarButtonSelected {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
   border-radius: 3px;
   background-color: #404040;
 }

--- a/mobile/themes/windows/ToolBarButton.css
+++ b/mobile/themes/windows/ToolBarButton.css
@@ -55,6 +55,10 @@
   display: inline-block;
   position: relative;
   overflow: hidden;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   border-radius: 0;
   border: none;
 }


### PR DESCRIPTION
The Samsung S4 default browser in Android 4.2.2 does not support border-radius CSS property anymore (regression in the webkit build ?). see https://bugs.dojotoolkit.org/ticket/17665 for details.
