### PR TITLE
Fixes #17165: during a scroll animation, touchstart should not trigger the selection of the item

### DIFF
--- a/mobile/_ItemBase.js
+++ b/mobile/_ItemBase.js
@@ -12,8 +12,10 @@ define([
 	"./TransitionEvent",
 	"./iconUtils",
 	"./sniff",
+	"./viewRegistry",
 	"dojo/has!dojo-bidi?dojox/mobile/bidi/_ItemBase"
-], function(array, declare, lang, win, domClass, touch, registry, Contained, Container, WidgetBase, TransitionEvent, iconUtils, has, BidiItemBase){
+], function(array, declare, lang, win, domClass, touch, registry, Contained, Container, 
+	WidgetBase, TransitionEvent, iconUtils, has, viewRegistry, BidiItemBase){
 
 	// module:
 	//		dojox/mobile/_ItemBase
@@ -319,6 +321,12 @@ define([
 			// tags:
 			//		private
 			if(this.getParent().isEditing || this.onTouchStart(e) === false){ return; } // user's touchStart action
+			var enclosingScrollable = viewRegistry.getEnclosingScrollable(this.domNode);
+			if(enclosingScrollable &&
+				domClass.contains(enclosingScrollable.containerNode, "mblScrollableScrollTo2")){
+				// #17165: do not select the item during scroll animation
+				return;
+			}
 			if(!this._onTouchEndHandle && this._selStartMethod === "touch"){
 				// Connect to the entire window. Otherwise, fail to receive
 				// events if operation is performed outside this widget.


### PR DESCRIPTION
When list items are in a ScrollableView, I don't see any good reason that touching the view during the scroll animation triggers the selection of the item. That is, in addition to solving the problem in #17615 (wrong item being selected in some browsers), avoiding the selection also has the benefit to avoid an unintentional selection. 

Tested on various Android, iOS, BB and WP8 devices without noticing any kind of regression (no perceived slowdown, for instance). 

Fixes [#17165](https://bugs.dojotoolkit.org/ticket/17165).
