### PR TITLE
fix extra keydown handler registration, fixes #17825

### DIFF
--- a/mobile/ListItem.js
+++ b/mobile/ListItem.js
@@ -185,11 +185,6 @@ define([
 					return (e.target !== this.labelNode);
 				};
 			}
-			if(opts.moveTo || opts.href || opts.url || this.clickable || (parent && parent.select)){
-				this.connect(this.domNode, "onkeydown", "_onClick"); // for desktop browsers
-			}else{
-				this._handleClick = false;
-			}
 
 			this.inherited(arguments);
 			

--- a/mobile/tests/doh/listitem/ListItem3_Programmatic.html
+++ b/mobile/tests/doh/listitem/ListItem3_Programmatic.html
@@ -12,6 +12,8 @@
 	require([
 		"dojox/mobile/parser",
 		"dojo/ready",
+		"dojo/on",
+		"dojo/aspect",
 		"dijit/registry",
 		"doh/runner",
 		"dojox/mobile/Heading",
@@ -19,7 +21,7 @@
 		"dojox/mobile",
 		"dojox/mobile/View",
 		"dojox/mobile/compat"
-	], function(parser, ready, registry, runner, Heading, ListItem){
+	], function(parser, ready, on, aspect, registry, runner, Heading, ListItem){
 
 		// This main purpose of this test is to check the correct handling of 
 		// calls AFTER startup of setters for the following properties of ListItem:
@@ -142,6 +144,13 @@
 						var widget = _createListItem2();
 						_assertCorrectListItem(widget, true, "touch", 
 							"ListItem created with clickable at true");
+						// check the keyboard event handler is registered once (#17825)
+						var c = 0;
+						aspect.after(widget, "_onClick", function(){
+							++c;
+						})
+						on.emit(widget.domNode, "keydown", { keyCode: 13, type: "keydown"});
+						runner.assertEqual(1, c, "Unexpected onClick() calls count.");
 					}
 				},
 				{


### PR DESCRIPTION
The dojox/mobile/ListItem keydown handler is called twice when a key is pressed. This is because the keydown handler is registered twice: first in ListItem.startup, then in ListIem._updateHandles, which is invoked indirectly when ListItem.startup() calls this.inherited().
Since ListItem._updateHandles() is invoked by ItemBase.startup(), this patch removes the useless event registration done in startup().
