### PR TITLE
Fixes #17822. Ensure onFlickAnimationStart() is triggered in all scrollTypes, and onFlickAnimationEnd() is not triggered twice when scrolling on one direction with scrollType=2

### DIFF
--- a/mobile/scrollable.js
+++ b/mobile/scrollable.js
@@ -176,7 +176,7 @@ define([
 				if(!this._useTopLeft){
 					if(this._useTransformTransition){
 						this._ch.push(connect.connect(this.domNode, css3.name("transitionEnd"), this, "onFlickAnimationEnd"));
-						this._ch.push(connect.connect(this.domNode, css3.name("transitionStart"), this, "onFlickAnimationStart"));
+						// Note that there is no transitionstart event (#17822).
 					}else{
 						this._ch.push(connect.connect(this.domNode, css3.name("animationEnd"), this, "onFlickAnimationEnd"));
 						this._ch.push(connect.connect(this.domNode, css3.name("animationStart"), this, "onFlickAnimationStart"));
@@ -193,7 +193,7 @@ define([
 					}
 				}else{
 					this._ch.push(connect.connect(this.domNode, css3.name("transitionEnd"), this, "onFlickAnimationEnd"));
-					this._ch.push(connect.connect(this.domNode, css3.name("transitionStart"), this, "onFlickAnimationStart"));
+					// Note that there is no transitionstart event (#17822).
 				}
 			}
 
@@ -388,7 +388,9 @@ define([
 		},
 
 		onFlickAnimationStart: function(e){
-			event.stop(e);
+			if(e){
+				event.stop(e);
+			}
 		},
 
 		onFlickAnimationEnd: function(e){
@@ -1241,6 +1243,7 @@ define([
 						if(to.y === undefined){ to.y = from.y; }
 						 // make sure we actually change the transform, otherwise no webkitTransitionEnd is fired.
 						if(to.x !== from.x || to.y !== from.y){
+							this.onFlickAnimationStart(); // needed because there is no transitionstart event.
 							domStyle.set(node, css3.add({}, {
 								transitionProperty: css3.name("transform"),
 								transitionDuration: duration + "s",
@@ -1272,17 +1275,27 @@ define([
 							this.scrollScrollBarTo(to);
 						}
 					}
-				}else{
+				}else if(to.x !== undefined || to.y !== undefined){
+					this.onFlickAnimationStart(); // #17822: needed because there is no transitionstart event.
 					domStyle.set(node, css3.add({}, {
-						transitionProperty: "top, left",
+						// #17822: when scrolling on one direction, avoid unnecessarily animating 
+						// both top and left, because this leads to two transitionend events fired 
+						// instead of one in some browsers (Safari/iOS7 at least).
+						transitionProperty: (to.x !== undefined && to.y !== undefined) ?
+							"top, left" :
+							to.y !== undefined ? "top" : "left",
 						transitionDuration: duration + "s",
 						transitionTimingFunction: easing
 					}));
 					setTimeout(function(){ // setTimeout is needed to prevent webkitTransitionEnd not fired
-						domStyle.set(node, {
-							top: (to.y || 0) + "px",
-							left: (to.x || 0) + "px"
-						});
+						var style = {};
+						if(to.x !== undefined){
+							style.left = to.x + "px";
+						}
+						if(to.y !== undefined){
+							style.top = to.y + "px";
+						}
+						domStyle.set(node, style);
 					}, 0);
 					domClass.add(node, "mblScrollableScrollTo"+idx);
 				}

--- a/mobile/tests/doh/view/ScrollableView_Programmatic.html
+++ b/mobile/tests/doh/view/ScrollableView_Programmatic.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+	<meta name="viewport"
+		content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no"/>
+	<meta name="apple-mobile-web-app-capable" content="yes"/>
+	<title>ScrollableView</title>
+
+	<!-- Test for ScrollableView's onFlickAnimationStart/End (Trac #17822) -->
+	
+	<script type="text/javascript" src="../../../deviceTheme.js"></script>
+	<script type="text/javascript" src="../../../../../dojo/dojo.js" 
+		data-dojo-config="async: true, parseOnLoad: true"></script>
+
+	<script type="text/javascript">
+		var onYearSet, onMonthSet, onDaySet;
+		require([
+			"dojo/ready", "dojo/dom-construct", "dijit/registry", "doh/runner",
+			"dojox/mobile/ScrollableView", "dojox/mobile", "dojox/mobile/compat", "dojox/mobile/parser"],
+			function(ready, domConstruct, registry, runner, ScrollableView){
+						
+			var onFlickAnimationStartCounter, onFlickAnimationEndCounter;
+
+			ready(function(){
+				var installCounters = function(scrollableView){
+					scrollableView.on("flickAnimationStart", function(){
+						onFlickAnimationStartCounter++;
+					});
+					scrollableView.on("flickAnimationEnd", function(){
+						onFlickAnimationEndCounter++;
+					});
+				};
+				
+				var initCounters = function(){
+					onFlickAnimationStartCounter = onFlickAnimationEndCounter = 0;
+				};
+				
+				var checkCounters = function(scrollType, expectedStartCounter, expectedEndCounter){
+					var msg = "scrollType: " + scrollType;
+					runner.assertEqual(expectedStartCounter, onFlickAnimationStartCounter, 
+						msg + " Unexpected onFlickAnimationStartCounter");
+					runner.assertEqual(expectedEndCounter, onFlickAnimationEndCounter, 
+						msg + " Unexpected onFlickAnimationEndCounter");
+				};
+				
+				var createScrollableView = function(scrollType){
+					var scrollableView = new ScrollableView({scrollType: scrollType});
+					installCounters(scrollableView);
+					document.body.innerHTML = "";
+					document.body.appendChild(scrollableView.domNode);
+					scrollableView.startup();
+					var rect = domConstruct.create("div");
+					// larger than the ScrollableView to ensure actual scroll
+					rect.style.height = "1000px";
+					scrollableView.containerNode.appendChild(rect);
+					scrollableView.style.height = "500px";
+					scrollableView.startup();
+					scrollableView.resize();
+					return scrollableView;
+				};
+				
+				var testScrollableView = function(scrollType){
+					var scrollableView = createScrollableView(scrollType);
+					initCounters();
+					scrollableView.slideTo({y: -100}, 0.2/*duration*/); // animated scroll 
+					var d = new runner.Deferred();
+					// setTimeout used because onFlickAnimationEnd is called asynchronously
+					setTimeout(d.getTestCallback(function(){
+						checkCounters(scrollType, 1, 1);
+  					}), 1000);
+					return d;
+				};
+				
+				runner.register("dojox.mobile.test.doh.ScrollableView", [
+					{
+						name: "onFlickAnimationStart/End scrollType 1",
+						timeout: 2000,
+						runTest: function(){
+							testScrollableView(1);
+						}
+					},
+					{
+						name: "onFlickAnimationStart/End scrollType 2",
+						timeout: 2000,
+						runTest: function(){
+							return testScrollableView(2);
+						}
+					},
+					{
+						name: "onFlickAnimationStart/End scrollType 3",
+						timeout: 2000,
+						runTest: function(){
+							return testScrollableView(3);
+						}
+					}
+				]);
+				
+				runner.run();
+			});
+		});
+		</script>
+	</head>
+	<body style="visibility:hidden;">
+	</body>
+</html>

--- a/mobile/tests/doh/view/module.js
+++ b/mobile/tests/doh/view/module.js
@@ -4,8 +4,7 @@ define(["doh/main", "require", "dojo/sniff"], function(doh, require, has){
 	doh.registerUrl("dojox.mobile.tests.doh.View", require.toUrl("./View_Programmatic.html"),999999);
 	doh.registerUrl("dojox.mobile.tests.doh.View", require.toUrl("./View2_Programmatic.html"),999999);
 	doh.registerUrl("dojox.mobile.tests.doh.View", require.toUrl("./View3_Programmatic.html"),999999);
+	doh.registerUrl("dojox.mobile.tests.doh.View", require.toUrl("./ScrollableView_Programmatic.html"),999999);
 	doh.registerUrl("dojox.mobile.tests.doh.View", require.toUrl("./View-demo.html"),999999);
 });
-
-
 


### PR DESCRIPTION
Replaces #85.
