### PR TITLE
Fix #17941 dojox/widget/UpgradeBar is using deprecated dojo.cache and causes build to fail.

### DIFF
--- a/widget/UpgradeBar.js
+++ b/widget/UpgradeBar.js
@@ -12,7 +12,6 @@ define([
 	"dojo/dom-construct", // domConstruct.destroy
 	"dojo/dom-geometry", // domGeo.getContentBox
 	"dojo/dom-style", // style.get, style.set
-	"dojo/cache", // cache
 	"dojo/cookie", // cookie
 	"dojo/domReady", // domReady
 	"dojo/fx", // fx.combine
@@ -21,7 +20,7 @@ define([
 	"dijit/_TemplatedMixin", // _TemplatedMixin
 	"dojo/text!./UpgradeBar/UpgradeBar.html"
 ], function(dojo, array, connect, declare, baseFx, lang, has, baseWin,
-            domAttr, domClass, domConstruct, domGeo, style, cache, cookie,
+            domAttr, domClass, domConstruct, domGeo, style, cookie,
             domReady, fx, win, _WidgetBase, _TemplatedMixin, template){
 
 dojo.experimental("dojox.widget.UpgradeBar");


### PR DESCRIPTION
As per https://bugs.dojotoolkit.org/ticket/17941#ticket

The dojox/widget/UpgradeBar is using dojo.cache which is deprecated according to http://dojotoolkit.org/reference-guide/1.9/dojo/cache.html. 
The problem is in the following part of the file

```
templateString: cache("dojox.widget","UpgradeBar/UpgradeBar.html"),
```

This is also **causing builds to fail** because dojox/widget/UpgradeBar/UpgradeBar.html is getting required in the built layer.

The resolution is to easily replace it with dojo/text! Just like https://github.com/dojo/dojox/blob/master/widget/Wizard.js Funny how Wizard was using dojo/text! but UpgradeBar was not!

I have tested the solution with the test_UpgradeBar.html and test_UpgradeBar_markup.html files.

My CLA is on File!
