### PR TITLE
Fix https://bugs.dojotoolkit.org/ticket/17229

### DIFF
--- a/mobile/Overlay.js
+++ b/mobile/Overlay.js
@@ -48,8 +48,10 @@ define([
 		 	// reposition if needed 
 		 	if((popupPos.y+popupPos.h) != vp.h // TODO: should be a has() test for position:fixed not scrolling
 				|| (domStyle.get(this.domNode, 'position') != 'absolute' && has('android') < 3)){ // android 2.x supports position:fixed but child transforms don't persist
-				popupPos.y = vp.t + vp.h - popupPos.h;
-				domStyle.set(this.domNode, { position: "absolute", top: popupPos.y + "px", bottom: "auto" });
+		 		this.defer(lang.hitch(this, function(){ // Need to use a defer or this is not working on iOS 5
+					popupPos.y = vp.t + vp.h - popupPos.h;
+					domStyle.set(this.domNode, { position: "absolute", top: popupPos.y + "px", bottom: "auto" });
+		 		}));
 			}
 			return popupPos;
 		},

--- a/mobile/tests/test_Overlay.html
+++ b/mobile/tests/test_Overlay.html
@@ -44,6 +44,9 @@
 	<br>
 	<button onclick="dijit.byId('customPicker').show()">pop up</button>
 	<button onclick="dijit.byId('customPicker').hide()">pop down</button>
+	<p>
+	Test: click the pop up button and check that the overlay is correctly opened at the bottom of the viewport. Then click the Done button of the overlay, scroll to the bottom of the page and click the pop up button there. Check
+	that the overlay is correctly displayed at the bottom of the viewport.
 	<div id="customPicker" data-dojo-type="dojox.mobile.Overlay">
 		<h1 data-dojo-type="dojox.mobile.Heading" data-dojo-props='label:"Custom Picker"'>
 			<span data-dojo-type="dojox.mobile.ToolBarButton"  data-dojo-props='label:"Done"' class="mblColorBlue" style="width:45px;float:right;" onClick="dijit.byId('customPicker').hide()"></span>


### PR DESCRIPTION
when used inside a ScrollableView, the Overlay can appear at a wrong location thus being invisible
