### PR TITLE
Workaround Firefox SVG issue.  fixes: 18062

### DIFF
--- a/gfx/fx.js
+++ b/gfx/fx.js
@@ -276,7 +276,7 @@ define(["dojo/_base/lang", "./_base", "./matrix", "dojo/_base/Color", "dojo/_bas
 			this.curve = new InterpolTransform(args.transform, original);
 		});
 		Hub.connect(anim, "onAnimate", shape, "setTransform");
-		if(g.renderer === "svg" && has("ie") >= 10){
+		if(g.renderer === "svg" && (has("ie") >= 9 || has("ff"))){
 			// fix http://bugs.dojotoolkit.org/ticket/16879
 			var handlers = [
 					Hub.connect(anim, "onBegin", anim, function(){
@@ -286,6 +286,13 @@ define(["dojo/_base/lang", "./_base", "./matrix", "dojo/_base/Color", "dojo/_bas
 						}
 						if(parent){
 							shape.__svgContainer = parent.rawNode.parentNode;
+							shape.__svgRoot = parent.rawNode;
+							if(shape.__svgRoot && shape.__svgRoot.getAttribute){
+								shape.__svgWidth = parseInt(shape.__svgRoot.getAttribute("width"), 10);
+								if(isNaN(shape.__svgWidth)){
+									delete shape.__svgWidth;
+								}
+							}
 						}
 					}),
 					Hub.connect(anim, "onAnimate", anim, function(){
@@ -295,23 +302,44 @@ define(["dojo/_base/lang", "./_base", "./matrix", "dojo/_base/Color", "dojo/_bas
 								shape.__svgContainer.style.visibility = "visible";
 								var pokeNode = shape.__svgContainer.offsetHeight;
 								shape.__svgContainer.style.visibility = ov;
+								var width = shape.__svgWidth;
+								if(!isNaN(width)){
+									try{
+										shape.__svgRoot.setAttribute("width", width  - 0.000005);
+										shape.__svgRoot.setAttribute("width", width);
+									}catch(ignore){}
+								}
 							}
 						}catch(e){}
 					}),
 					Hub.connect(anim, "onEnd", anim, function(){
 						arr.forEach(handlers, Hub.disconnect);
 						if(shape.__svgContainer){
-							var ov = shape.__svgContainer.style.visibility;
 							var sn = shape.__svgContainer;
-							shape.__svgContainer.style.visibility = "visible";
-							setTimeout(function(){
-								try{
-									sn.style.visibility = ov;
-									sn = null;
-								}catch(e){}
-							},100);
+							if(sn.getAttribute("__gotVis") == null){
+								sn.setAttribute("__gotVis", true);
+								var ov = shape.__svgContainer.style.visibility;
+								var root = shape.__svgRoot;
+								var width = shape.__svgWidth;
+								sn.style.visibility = "visible";
+								setTimeout(function(){
+									try{
+										sn.style.visibility = ov;
+										sn.removeAttribute("__gotVis");
+										sn = null;
+										try{
+											if(!isNaN(width)){
+												root.setAttribute("width", width - 0.000005);
+												root.setAttribute("width", width);
+											}
+										}catch(ignore){}
+									}catch(e){}
+								},100);
+							}
 						}
 						delete shape.__svgContainer;
+						delete shape.__svgRoot;
+						delete shape.__svgWidth;
 					})
 				];
 		}


### PR DESCRIPTION
This is an enhancement to the original IE fix for mis-rendering of SVG during animation due to browser bugs.  It adds in a workaround to a similar Firefox issue due to Cairo.   ​https://bugzilla.mozilla.org/show_bug.cgi?id=847153

This is related to dojo bug:
https://bugs.dojotoolkit.org/ticket/18062