### PR TITLE
Fixes #18065, old alias for the dojo global to be replaced by lang

### DIFF
--- a/widget/Rotator.js
+++ b/widget/Rotator.js
@@ -137,7 +137,7 @@ define([
 			tt[t] = lang.getObject(t);
 			if(!tt[t]){
 				warn(t, _defaultTransition);
-				tt[_t.transition = _defaultTransition] = d.getObject(_defaultTransition);
+				tt[_t.transition = _defaultTransition] = lang.getObject(_defaultTransition);
 			}
 
 			// clean up the transition params


### PR DESCRIPTION
Came across this issue (#18065) when trying to use these - it seems that an old reference from the non-AMD code was left around when moved over to AMD. This is a trivial change that addresses the issue (has been working for me)
