### PR TITLE
 different alignments for the chart title (T18078)

### DIFF
--- a/charting/Chart.js
+++ b/charting/Chart.js
@@ -169,7 +169,8 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 			this.titlePos  = kwArgs.titlePos;
 			this.titleFont = kwArgs.titleFont;
 			this.titleFontColor = kwArgs.titleFontColor;
-			this.titleAlign = kwArgs.titleAlign; // This can be middle, left, right, or edge (edge is left or right aligned with chart edge depending on bidi).
+			this.titleAlign = kwArgs.titleAlign; // This can be middle, left, right, or edge 
+															 // edge is left or right aligned with chart plot edge depending on bidi.
 			this.chartTitle = null;
 			this.htmlLabels = true;
 			if("htmlLabels" in kwArgs){

--- a/charting/Chart.js
+++ b/charting/Chart.js
@@ -169,6 +169,7 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 			this.titlePos  = kwArgs.titlePos;
 			this.titleFont = kwArgs.titleFont;
 			this.titleFontColor = kwArgs.titleFontColor;
+			this.titleAlign = kwArgs.titleAlign; // This can be middle, left, right, or edge (edge is left or right aligned with chart edge depending on bidi).
 			this.chartTitle = null;
 			this.htmlLabels = true;
 			if("htmlLabels" in kwArgs){
@@ -850,6 +851,7 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 				this.titlePos = this.titlePos || this.theme.chart.titlePos || "top";
 				this.titleFont = this.titleFont || this.theme.chart.titleFont;
 				this.titleFontColor = this.titleFontColor || this.theme.chart.titleFontColor || "black";
+				this.titleAlign = this.titleAlign || this.theme && this.theme.chart && this.theme.chart.titleAlign || "middle";
 				var tsize = g.normalizedLength(g.splitFontString(this.titleFont).size);
 				offsets[this.titlePos == "top" ? "t" : "b"] += (tsize + this.titleGap);
 			}
@@ -953,19 +955,7 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 
 			//create title: Whether to make chart title as a widget which extends dojox.charting.Element?
 			if(this.title){
-				var forceHtmlLabels = (g.renderer == "canvas") && this.htmlLabels,
-					labelType = forceHtmlLabels || !has("ie") && !has("opera") && this.htmlLabels ? "html" : "gfx",
-					tsize = g.normalizedLength(g.splitFontString(this.titleFont).size);
-				this.chartTitle = common.createText[labelType](
-					this,
-					this.surface,
-					dim.width/2,
-					this.titlePos=="top" ? tsize + this.margins.t : dim.height - this.margins.b,
-					"middle",
-					this.title,
-					this.titleFont,
-					this.titleFontColor
-				);
+				this._renderTitle(dim, offsets);
 			}
 
 			// go over axes
@@ -974,6 +964,51 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 			this._makeClean();
 
 			return this;	//	dojox/charting/Chart
+		},
+		_renderTitle: function(dim, offsets){
+			// summary:
+			//		Internal function to render the chart title.
+			// dim:
+			//		The dimension object of the chart
+			// tags:
+			//		private
+			var forceHtmlLabels = (g.renderer == "canvas") && this.htmlLabels,
+				labelType = forceHtmlLabels || !has("ie") && !has("opera") && this.htmlLabels ? "html" : "gfx",
+				tsize = g.normalizedLength(g.splitFontString(this.titleFont).size),
+				tBox = g._base._getTextBox(this.title,{ font: this.titleFont });
+				
+			var titleAlign = this.titleAlign;
+			var isRtl = has("dojo-bidi") && this.isRightToLeft();
+			var posX = dim.width/2; // Default is middle.
+			if(titleAlign === "edge"){
+				titleAlign = "left";
+				if(isRtl){
+					posX = dim.width - (offsets.r + tBox.w);
+				}else {
+					posX = offsets.l;
+				}
+			}else if(titleAlign != "middle"){
+				if(isRtl){
+					// We're in BIDI mode, reverse the alignment.
+					titleAlign = titleAlign === "left" ? "right" : "left";
+				}
+				if(titleAlign === "left"){
+					posX = this.margins.l;
+				}else if(titleAlign === "right"){
+					titleAlign = "left";
+					posX = dim.width - (this.margins.l + tBox.w);
+				}
+			}
+			this.chartTitle = common.createText[labelType](
+				this,
+				this.surface,
+				posX,
+				this.titlePos=="top" ? tsize + this.margins.t : dim.height - this.margins.b,
+				titleAlign,
+				this.title,
+				this.titleFont,
+				this.titleFontColor
+			);
 		},
 		_renderChartBackground: function(dim, offsets){
 			var t = this.theme, rect;

--- a/charting/SimpleTheme.js
+++ b/charting/SimpleTheme.js
@@ -494,7 +494,8 @@ lang.mixin(SimpleTheme, {
 			titleGap:		20,
 			titlePos:		"top",
 			titleFont:      "normal normal bold 14pt Tahoma",	// chart title
-			titleFontColor: "#333"
+			titleFontColor: "#333",
+			titleAlign: "middle"
 		},
 		plotarea:{
 			stroke: null,

--- a/charting/bidi/Chart.js
+++ b/charting/bidi/Chart.js
@@ -137,24 +137,8 @@ define(["dojox/main", "dojo/_base/declare", "dojo/_base/lang", "dojo/dom-style",
 					
 					// recreate title
 					if(this.title){
-						var forceHtmlLabels = (g.renderer == "canvas"),
-							labelType = forceHtmlLabels || !has("ie") && !has("opera") ? "html" : "gfx",
-							tsize = g.normalizedLength(g.splitFontString(this.titleFont).size);
-						// remove the title
-						domConstruct.destroy(this.chartTitle);
-						this.chartTitle =null;
-						// create the new title
-						this.chartTitle = da.createText[labelType](
-							this,
-							this.surface,
-							this.dim.width/2,
-							this.titlePos=="top" ? tsize + this.margins.t : this.dim.height - this.margins.b,
-							"middle",
-							this.title,
-							this.titleFont,
-							this.titleFontColor
-						);
-					}				
+						this._renderTitle(this.dim, this.offsets);
+					}			
 				}else{
 					// case of pies, spiders etc.
 					arr.forEach(this.htmlElementsRegistry, function(elem, index, arr){

--- a/charting/tests/BidiSupport/mirror_axes.html
+++ b/charting/tests/BidiSupport/mirror_axes.html
@@ -78,6 +78,17 @@ makeObjects = function(){
             addSeries("Series C", [{x: 5, y: 3}, {x: 6, y: 4}, {x: 7, y: 3}]).
 			setDir("rtl").
             render();
+
+   var chart4 = new dojox.charting.Chart("test5", {title: "Chart Title", titleAlign: "edge"}).
+            setTheme(customTheme).
+            addAxis("x", {fixLower: "major", fixUpper: "major", natural: true, includeZero: true, majorTick: { length: -10}}).
+            addAxis("y", {vertical: true, fixLower: "major", fixUpper: "major", natural: true, includeZero: true}).
+            addPlot("default", {type: "Markers"}).
+            addSeries("Series A", [{x: 1, y: 1}, {x: 2, y: 2}, {x: 3, y: 1}]).
+            addSeries("Series B", [{x: 3, y: 2}, {x: 4, y: 3}, {x: 5, y: 2}]).
+            addSeries("Series C", [{x: 5, y: 3}, {x: 6, y: 4}, {x: 7, y: 3}]).
+			setDir("rtl").
+            render();
 };
 
 dojo.ready(makeObjects);
@@ -95,6 +106,8 @@ dojo.ready(makeObjects);
 <div id="test3" style="width: 200px; height: 200px;"></div>
 <p>4: Like #1 but no axes.</p>
 <div id="test4" style="width: 200px; height: 200px;"></div>
+<p>4: Like #1 but with the title aligned to the axis edge.</p>
+<div id="test5" style="width: 200px; height: 200px;"></div>
 <p>That's all Folks!</p>
 </body>
 </html>

--- a/charting/tests/test_chartTitle.html
+++ b/charting/tests/test_chartTitle.html
@@ -83,6 +83,67 @@ makeObjects = function(){
 			addSeries("Series A", [400, 800, 200, 600, 600], {stroke: {color: "red"}, fill: "lightpink"}).
 			addSeries("Series B", [200, 300, 500, 700, 800], {stroke: {color: "blue"}, fill: "lightblue"}).
 			render();
+			
+	var chart3 = new dojox.charting.Chart("test3", {
+				title: "Production(Quantity)", 
+				titleFont: "normal normal normal 15pt Arial",
+				titleFontColor: "orange",
+				titleAlign: "edge"
+			}).
+			addAxis("x", {
+				includeZero: true, natural: true, fixLower: "major", fixUpper: "major",
+				labels: [
+					{value: 0, text: ""},{value: 1, text: "Jan"},{value: 2, text: "Feb"},
+					{value: 3, text: "Mar"},{value: 4, text: "Aprl"},{value: 5, text: "May"}
+				]
+			}).
+			addAxis("y", {
+				vertical: true, includeZero: true, natural: true, fixLower: "major", fixUpper: "major", majorTickStep: 200
+			}).
+			addPlot("default", {type: "Lines"}).
+			addSeries("Series A", [400, 800, 200, 600, 600], {stroke: {color: "red"}, fill: "lightpink"}).
+			addSeries("Series B", [200, 300, 500, 700, 800], {stroke: {color: "blue"}, fill: "lightblue"}).
+			render();
+	var chart4 = new dojox.charting.Chart("test4", {
+				title: "Production(Quantity)", 
+				titleFont: "normal normal normal 15pt Arial",
+				titleFontColor: "orange",
+				titleAlign: "left"
+			}).
+			addAxis("x", {
+				includeZero: true, natural: true, fixLower: "major", fixUpper: "major",
+				labels: [
+					{value: 0, text: ""},{value: 1, text: "Jan"},{value: 2, text: "Feb"},
+					{value: 3, text: "Mar"},{value: 4, text: "Aprl"},{value: 5, text: "May"}
+				]
+			}).
+			addAxis("y", {
+				vertical: true, includeZero: true, natural: true, fixLower: "major", fixUpper: "major", majorTickStep: 200
+			}).
+			addPlot("default", {type: "Lines"}).
+			addSeries("Series A", [400, 800, 200, 600, 600], {stroke: {color: "red"}, fill: "lightpink"}).
+			addSeries("Series B", [200, 300, 500, 700, 800], {stroke: {color: "blue"}, fill: "lightblue"}).
+			render();
+	var chart5 = new dojox.charting.Chart("test5", {
+				title: "Production(Quantity)", 
+				titleFont: "normal normal normal 15pt Arial",
+				titleFontColor: "orange",
+				titleAlign: "right"
+			}).
+			addAxis("x", {
+				includeZero: true, natural: true, fixLower: "major", fixUpper: "major",
+				labels: [
+					{value: 0, text: ""},{value: 1, text: "Jan"},{value: 2, text: "Feb"},
+					{value: 3, text: "Mar"},{value: 4, text: "Aprl"},{value: 5, text: "May"}
+				]
+			}).
+			addAxis("y", {
+				vertical: true, includeZero: true, natural: true, fixLower: "major", fixUpper: "major", majorTickStep: 200
+			}).
+			addPlot("default", {type: "Lines"}).
+			addSeries("Series A", [400, 800, 200, 600, 600], {stroke: {color: "red"}, fill: "lightpink"}).
+			addSeries("Series B", [200, 300, 500, 700, 800], {stroke: {color: "blue"}, fill: "lightblue"}).
+			render();			
 };
 
 dojo.addOnLoad(makeObjects);
@@ -101,6 +162,12 @@ dojo.addOnLoad(makeObjects);
 <div id="test1" style="width: 400px; height: 300px;"></div>
 <p>Line chart with customized chart title</p>
 <div id="test2" style="width: 400px; height: 300px;"></div>
+<p>Line chart with edge aligned title</p>
+<div id="test3" style="width: 400px; height: 300px;"></div>
+<p>Line chart with left aligned title</p>
+<div id="test4" style="width: 400px; height: 300px;"></div>
+<p>Line chart with right aligned title</p>
+<div id="test5" style="width: 400px; height: 300px;"></div>
 
 </body>
 </html>


### PR DESCRIPTION
This is a pull request for dojo enhancement: https://bugs.dojotoolkit.org/ticket/18078.  It adds in the ability to specify different alignments for the chart title.  Originally, all the chart would do is center align a title.  This keeps that as the default, but allows for chart, or theme setting of titleAlign, which can now be: left, right, middle, edge.  The behavior is as defined:
left:  Align the title all the way to the left.
right:  Align the title all the way to the right.
edge:  Align the title to the edge of the plot where the axis is.

All of the above try to take into account bidi, which will generally flip them around.  left becomes right and so on.  The question I have is on edge.  In BIDI, do we mirror the axis to the right?  I assumed we do now, but I could not easily tell if it actually did that.  The current edge code assumes that too, which may not be accurate.  Please advise.
