### PR TITLE
Workaround BusyButton Unknown Runtime Error

### DIFF
--- a/form/BusyButton.js
+++ b/form/BusyButton.js
@@ -94,7 +94,7 @@ var _BusyButtonMixin = declare("dojox.form._BusyButtonMixin", null, {
 		while(this.containerNode.firstChild){
 			this.containerNode.removeChild(this.containerNode.firstChild);
 		}
-		this.containerNode.innerHTML = this.label;
+		this.containerNode.appendChild(document.createTextNode(this.label));
 
 		if(this.showLabel == false && !domAttr.get(this.domNode, "title")){
 			this.titleNode.title=lang.trim(this.containerNode.innerText || this.containerNode.textContent || '');


### PR DESCRIPTION
- Workaround Unknown Runtime Error
  - in some versions of Internet Explorer, an Unknown Runtime Error is thrown when the innerHTML of a DOM node is altered by a function which was invoked by a member of the innerHTML
  - since BusyButton#setLabel empties the containerNode, we can avoid this issue by simply appending a new TextNode to the containerNode (which should behave the same as setting the innerHTML to a String literal)
