### PR TITLE
Fix issue with dojox/html/metrics and font size, fixes #18080

### DIFF
--- a/html/metrics.js
+++ b/html/metrics.js
@@ -13,11 +13,15 @@ define(["dojo/_base/kernel","dojo/_base/lang", "dojo/_base/sniff", "dojo/ready",
 			'small':0, 'medium':0, 'large':0, 'x-large':0, 'xx-large':0
 		};
 	
+		var oldStyle;	
 		if(has("ie")){
-			//	we do a font-size fix if and only if one isn't applied already.
-			//	NOTE: If someone set the fontSize on the HTML Element, this will kill it.
-			Window.doc.documentElement.style.fontSize="100%";
-		}
+			//	We do a font-size fix if and only if one isn't applied already.
+			// NOTE: If someone set the fontSize on the HTML Element, this will kill it.
+			oldStyle = Window.doc.documentElement.style.fontSize || "";
+			if(!oldStyle){
+				Window.doc.documentElement.style.fontSize="100%";
+			}
+		}		
 	
 		//	set up the measuring node.
 		var div=Window.doc.createElement("div");
@@ -39,6 +43,11 @@ define(["dojo/_base/kernel","dojo/_base/lang", "dojo/_base/sniff", "dojo/ready",
 		for(var p in heights){
 			ds.fontSize = p;
 			heights[p] = Math.round(div.offsetHeight * 12/16) * 16/12 / 1000;
+		}
+
+		if(has("ie")){
+			// Restore the font to its old style.
+			Window.doc.documentElement.style.fontSize = oldStyle;
 		}
 		
 		Window.body().removeChild(div);


### PR DESCRIPTION
Simple patch to the metrics code to not leave a page in a mangled state on IE when font metrics are being calculated.  It only does transitory setting of the page font to get the initial numbers now as the original setting is restored at the end of the function.
