### PR TITLE
Minor fix to SVG to flatten negative dimensions to 0, fixed #18082

### DIFF
--- a/gfx/svg.js
+++ b/gfx/svg.js
@@ -192,7 +192,7 @@ function(lang, has, win, dom, declare, arr, domGeom, domAttr, Color, g, gs, path
 			if(s){
 				rn.setAttribute("stroke", s.color.toCss());
 				rn.setAttribute("stroke-opacity", s.color.a);
-				rn.setAttribute("stroke-width",   s.width);
+				rn.setAttribute("stroke-width",   s.width < 0 ? 0 : s.width);
 				rn.setAttribute("stroke-linecap", s.cap);
 				if(typeof s.join == "number"){
 					rn.setAttribute("stroke-linejoin",   "miter");
@@ -208,15 +208,15 @@ function(lang, has, win, dom, declare, arr, domGeom, domAttr, Color, g, gs, path
 					da = lang._toArray(da);
 					var i;
 					for(i = 0; i < da.length; ++i){
-						da[i] *= s.width;
+						da[i] *= (s.width < 0 ? 0 : s.width);
 					}
 					if(s.cap != "butt"){
 						for(i = 0; i < da.length; i += 2){
-							da[i] -= s.width;
+							da[i] -= (s.width < 0 ? 0 : s.width);
 							if(da[i] < 1){ da[i] = 1; }
 						}
 						for(i = 1; i < da.length; i += 2){
-							da[i] += s.width;
+							da[i] += (s.width < 0 ? 0 : s.width);
 						}
 					}
 					da = da.join(",");
@@ -263,8 +263,8 @@ function(lang, has, win, dom, declare, arr, domGeom, domAttr, Color, g, gs, path
 				var img = _createElementNS(svgns, "image");
 				img.setAttribute("x", 0);
 				img.setAttribute("y", 0);
-				img.setAttribute("width",  f.width .toFixed(8));
-				img.setAttribute("height", f.height.toFixed(8));
+				img.setAttribute("width",  (f.width < 0 ? 0 : f.width).toFixed(8));
+				img.setAttribute("height", (f.height < 0 ? 0 : f.height).toFixed(8));
 				_setAttributeNS(img, svg.xmlns.xlink, "xlink:href", f.src);
 				fill.appendChild(img);
 			}else{
@@ -334,7 +334,11 @@ function(lang, has, win, dom, declare, arr, domGeom, domAttr, Color, g, gs, path
 			this.shape = g.makeParameters(this.shape, newShape);
 			for(var i in this.shape){
 				if(i != "type"){
-					this.rawNode.setAttribute(i, this.shape[i]);
+					var v = this.shape[i];
+					if(i === "width" || i === "height"){
+						v = v < 0 ? 0 : v;
+					}
+					this.rawNode.setAttribute(i, v);
 				}
 			}
 			this.bbox = null;
@@ -459,7 +463,11 @@ function(lang, has, win, dom, declare, arr, domGeom, domAttr, Color, g, gs, path
 			this.bbox = null;
 			for(var i in this.shape){
 				if(i != "type" && i != "r"){
-					this.rawNode.setAttribute(i, this.shape[i]);
+					var v = this.shape[i];
+					if(i === "width" || i === "height"){
+						v = v < 0 ? 0 : v;
+					}
+					this.rawNode.setAttribute(i, v);
 				}
 			}
 			if(this.shape.r != null){
@@ -521,7 +529,11 @@ function(lang, has, win, dom, declare, arr, domGeom, domAttr, Color, g, gs, path
 			var rawNode = this.rawNode;
 			for(var i in this.shape){
 				if(i != "type" && i != "src"){
-					rawNode.setAttribute(i, this.shape[i]);
+					var v = this.shape[i];
+					if(i === "width" || i === "height"){
+						v = v < 0 ? 0 : v;
+					}
+					rawNode.setAttribute(i, v);
 				}
 			}
 			rawNode.setAttribute("preserveAspectRatio", "none");
@@ -740,11 +752,11 @@ else
 			// height: String
 			//		height of surface, e.g., "100px"
 			if(!this.rawNode){ return this; }
-			this.rawNode.setAttribute("width",  width);
-			this.rawNode.setAttribute("height", height);
+			this.rawNode.setAttribute("width",  width < 0 ? 0 : width);
+			this.rawNode.setAttribute("height", height < 0 ? 0 : height);
 			if(hasSvgSetAttributeBug){
-				this.rawNode.style.width =  width;
-				this.rawNode.style.height =  height;
+				this.rawNode.style.width =  width < 0 ? 0 : width;
+				this.rawNode.style.height =  height < 0 ? 0 : height;
 			}
 			return this;	// self
 		},
@@ -774,10 +786,10 @@ else
 		s.rawNode = _createElementNS(svg.xmlns.svg, "svg");
 		s.rawNode.setAttribute("overflow", "hidden");
 		if(width){
-			s.rawNode.setAttribute("width",  width);
+			s.rawNode.setAttribute("width",  width < 0 ? 0 : width);
 		}
 		if(height){
-			s.rawNode.setAttribute("height", height);
+			s.rawNode.setAttribute("height", height < 0 ? 0 : height);
 		}
 
 		var defNode = _createElementNS(svg.xmlns.svg, "defs");
@@ -947,6 +959,9 @@ else
 		// override createSurface()
 		svg.createSurface = function(parentNode, width, height){
 			var s = new svg.Surface();
+			
+			width = width < 0 ? 0 : width;
+			height = height < 0 ? 0 : height;
 
 			// ensure width / height
 			if(!width || !height){


### PR DESCRIPTION
This is a minor enhancement/cleanup patch to normalize negative items back to 0 to avoid chrome emitting annoying messages in the debug console.   See dojo ticket: https://bugs.dojotoolkit.org/ticket/18082
