### PR TITLE
Emit empty change record when file input value is cleared

### DIFF
--- a/form/FileUploader.js
+++ b/form/FileUploader.js
@@ -1021,11 +1021,18 @@ return declare("dojox.form.FileUploader", [Widget, TemplatedMixin, Contained], {
 		}));
 		this._cons.push(connect.connect(this._fileInput, "change", this, function(){
 			this._checkHtmlCancel("change");
-			this._change([{
-				name: this._fileInput.value,
-				type: "",
-				size: 0
-			}]);
+			var name = this._fileInput.value;
+			if(name){
+				this._change([{
+					name: name,
+					type: "",
+					size: 0
+				}]);
+			}else{
+				// If input's value is empty it's been cleared so we emit an empty change record
+				this._change([]);
+			}
+			
 		}));
 		if(this.tabIndex>=0){
 			domAttr.set(this.domNode, "tabIndex", this.tabIndex);


### PR DESCRIPTION
Chrome clears the file input value when the file selection dialog is cleared.
If a file was already chosen this creates a change, but the data array
provided to `onChange` wasn't accounting for this so a dummy file object
gets passed instead of an array.
