### PR TITLE
fix ContentPane to clean up style nodes

### DIFF
--- a/layout/ContentPane.js
+++ b/layout/ContentPane.js
@@ -88,7 +88,15 @@ return declare("dojox.layout.ContentPane", ContentPane, {
 		};
 
 		this.inherited("_setContent", arguments);
-	}
+	},
 	// could put back _renderStyles by wrapping/aliasing dojox.html._ContentSetter.prototype._renderStyles
+
+	destroy: function () {
+		var setter = this._contentSetter;
+		if (setter) {
+			setter.teardown();
+		}
+		this.inherited(arguments);
+	}
 });
 });


### PR DESCRIPTION
Clean up style nodes that are created and placed in the document head
when destroy is called on a ContentPane with renderStyles set to true
When renderStyles is true, <style> nodes are created in the head of the
document but are not cleaned up when the ContentPane is destroyed. Fixes #18175
