### PR TITLE
Enhance Pie plot with several features and layout improvements.

### DIFF
--- a/charting/SimpleTheme.js
+++ b/charting/SimpleTheme.js
@@ -134,12 +134,14 @@ define(["dojo/_base/lang", "dojo/_base/array","dojo/_base/declare","dojo/_base/C
 	//	|		markerStroke:  {width: 1.5, color: "#333"},		// marker stroke
 	//	|		markerOutline: {width: 0.1, color: "#ccc"},		// marker outline
 	//	|		markerShadow: null,								// no marker shadow
-	//	|	}
+	//	|	},
+	//	|	pieInnerRadius: 33
 	//
 	// example:
 	//		Defining a new theme is pretty simple:
 	//	|	var Grasslands = new SimpleTheme({
-	//	|		colors: [ "#70803a", "#dde574", "#788062", "#b1cc5d", "#eff2c2" ]
+	//	|		colors: [ "#70803a", "#dde574", "#788062", "#b1cc5d", "#eff2c2" ],
+	//	|		pieInnerRadius: 15
 	//	|	});
 	//	|
 	//	|	myChart.setTheme(Grasslands);
@@ -205,7 +207,8 @@ define(["dojo/_base/lang", "dojo/_base/array","dojo/_base/declare","dojo/_base/C
 			markerThemes: this.markerThemes,
 			// flags
 			noGradConv: this.noGradConv,
-			noRadialConv: this.noRadialConv
+			noRadialConv: this.noRadialConv,
+			pieInnerRadius: this.pieInnerRadius
 		});
 		// copy custom methods
 		arr.forEach(

--- a/charting/SimpleTheme.js
+++ b/charting/SimpleTheme.js
@@ -133,7 +133,7 @@ define(["dojo/_base/lang", "dojo/_base/array","dojo/_base/declare","dojo/_base/C
 	//	|		markerSymbol:  "m-3,0 c0,-4 6,-4 6,0 m-6,0 c0,4 6,4 6,0",	// marker symbol
 	//	|		markerStroke:  {width: 1.5, color: "#333"},		// marker stroke
 	//	|		markerOutline: {width: 0.1, color: "#ccc"},		// marker outline
-	//	|		markerShadow: null,								// no marker shadow
+	//	|		markerShadow: null								// no marker shadow
 	//	|	},
 	//	|	pieInnerRadius: 33
 	//

--- a/charting/plot2d/Pie.js
+++ b/charting/plot2d/Pie.js
@@ -1,57 +1,57 @@
-define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare", 
+define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare", "dojo/dom-geometry", "dojo/_base/Color",
 		"./Base", "./_PlotEvents", "./common",
 		"dojox/gfx", "dojox/gfx/matrix", "dojox/lang/functional", "dojox/lang/utils","dojo/has"],
-	function(lang, arr, declare, Base, PlotEvents, dc, g, m, df, du, has){
+	function(lang, arr, declare, domGeom, Color, Base, PlotEvents, dc, g, m, df, du, has){
 
 	/*=====
 	declare("dojox.charting.plot2d.__PieCtorArgs", dojox.charting.plot2d.__DefaultCtorArgs, {
 		// summary:
 		//		Specialized keyword arguments object for use in defining parameters on a Pie chart.
-	
+
 		// labels: Boolean?
 		//		Whether or not to draw labels for each pie slice.  Default is true.
 		labels:			true,
-	
+
 		// ticks: Boolean?
 		//		Whether or not to draw ticks to labels within each slice. Default is false.
 		ticks:			false,
-	
+
 		// fixed: Boolean?
 		//		Whether a fixed precision must be applied to data values for display. Default is true.
 		fixed:			true,
-	
+
 		// precision: Number?
 		//		The precision at which to round data values for display. Default is 0.
 		precision:		1,
-	
+
 		// labelOffset: Number?
 		//		The amount in pixels by which to offset labels.  Default is 20.
 		labelOffset:	20,
-	
+
 		// labelStyle: String?
 		//		Options as to where to draw labels.  Values include "default", and "columns".	Default is "default".
 		labelStyle:		"default",	// default/columns
-		
+
 		// omitLabels: Boolean?
 		//		Whether labels of slices small to the point of not being visible are omitted.	Default false.
 		omitLabels: false,
-		
+
 		// htmlLabels: Boolean?
 		//		Whether or not to use HTML to render slice labels. Default is true.
 		htmlLabels:		true,
-	
+
 		// radGrad: String?
 		//		The type of radial gradient to use in rendering.  Default is "native".
 		radGrad:        "native",
-	
+
 		// fanSize: Number?
 		//		The amount for a radial gradient.  Default is 5.
 		fanSize:		5,
-	
+
 		// startAngle: Number?
 		//		Where to being rendering gradients in slices, in degrees.  Default is 0.
 		startAngle:     0,
-	
+
 		// radius: Number?
 		//		The size of the radial gradient.  Default is 0.
 		radius:		0,
@@ -71,7 +71,17 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 
 		// styleFunc: Function?
 		//		A function that returns a styling object for the a given data item.
-		styleFunc:	null
+		styleFunc:	null,
+
+		// innerRadius: Number?
+		//		The inner radius of a ring in percent (0-100).  If value < 0
+		//		then it is assumed to be pixels, not percent.
+		innerRadius:	0,
+
+		//  minWidth: Number?
+		//      The minimum width of a pie slice at its chord. The default is 10px.
+		minWidth:   10
+
 	});
 	=====*/
 
@@ -88,9 +98,12 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 			labelOffset:	20,
 			labelStyle:		"default",	// default/columns
 			htmlLabels:		true,		// use HTML to draw labels
-			radGrad:        "native",	// or "linear", or "fan"
-			fanSize:		5,			// maximum fan size in degrees
-			startAngle:     0			// start angle for slices in degrees
+			radGrad:       "native",	// or "linear", or "fan"
+			fanSize:		   5,			// maximum fan size in degrees
+			startAngle:    0,			// start angle for slices in degrees
+			innerRadius:	0,			// inner radius in pixels
+			minWidth:      0,			// minimal width of degenerated slices
+			zeroDataMessage: ""     // The message to display when there is no data, if provided by the user.
 		},
 		optionalParams: {
 			radius:		0,
@@ -116,7 +129,10 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 			this.axes = [];
 			this.run = null;
 			this.dyn = [];
-			this.runFilter = []; 
+			this.runFilter = [];
+			if(kwArgs && kwArgs.hasOwnProperty("innerRadius")){
+				this._plotSetInnerRadius = true;
+			}
 		},
 		clear: function(){
 			// summary:
@@ -155,14 +171,15 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 			//		Return the number of colors needed to draw this plot.
 			return this.run ? this.run.data.length : 0;
 		},
+
 		render: function(dim, offsets){
-			// summary:
+			//	summary:
 			//		Render the plot on the chart.
-			// dim: Object
+			//	dim: Object
 			//		An object of the form { width, height }.
-			// offsets: Object
+			//	offsets: Object
 			//		An object of the form { l, r, t, b }.
-			// returns: dojox/charting/plot2d/Pie
+			//	returns: dojox/charting/plot2d/Pie
 			//		A reference to this plot for functional chaining.
 			if(!this.dirty){ return this; }
 			this.resetEvents();
@@ -171,96 +188,106 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 			this.cleanGroup();
 			var s = this.group, t = this.chart.theme;
 
-			if(!this.run || !this.run.data.length){
-				return this;
+			if(!this._plotSetInnerRadius && t && t.pieInnerRadius){
+				this.opt.innerRadius = t.pieInnerRadius;
 			}
 
 			// calculate the geometry
 			var rx = (dim.width  - offsets.l - offsets.r) / 2,
 				ry = (dim.height - offsets.t - offsets.b) / 2,
 				r  = Math.min(rx, ry),
-				labelFont = "font" in this.opt ? this.opt.font : t.series.font,
-				size,
+				taFont = "font" in this.opt ? this.opt.font : t.axis.tick.titleFont || "",
+				size = taFont ? g.normalizedLength(g.splitFontString(taFont).size) : 0,
+				taFontColor = this.opt.hasOwnProperty("fontColor") ? this.opt.fontColor : t.axis.tick.fontColor,
 				startAngle = m._degToRad(this.opt.startAngle),
 				start = startAngle, filteredRun, slices, labels, shift, labelR,
+				run = this.run.data,
 				events = this.events();
 
-			var run = arr.map(this.run.data, function(item, i){
-				if(typeof item != "number" && item.hidden){ 
-					this.runFilter.push(i); 
-					item.hidden = false; 
-				} 
-				if(arr.some(this.runFilter, function(filter){return filter == i;})){ 
-					if(typeof item == "number"){ 
-						return 0; 
-					}else{ 
-						return {y: 0, text: item.text}; 
-					} 
-				}else{ 
-					return item; 
-				} 
-			}, this);
+			/* Added to handle no data case */
+			var noDataFunc = lang.hitch(this, function(){
+				var ct = t.clone();
+				var themes = df.map(run, function(v){
+					var tMixin = [this.opt, this.run];
+					if(v !== null && typeof v != "number"){
+						tMixin.push(v);
+					}
+					if(this.opt.styleFunc){
+						tMixin.push(this.opt.styleFunc(v));
+					}
+					return ct.next("slice", tMixin, true);
+				}, this);
 
-			this.dyn = [];
+				// Draw initial pie, with text in it noting 0 data.
+				if("radius" in this.opt){
+					r = this.opt.radius < r ? this.opt.radius : r;
+				}
 
-			if("radius" in this.opt){
-				r = this.opt.radius;
-				labelR = r - this.opt.labelOffset;
+				var circle = {
+					cx: offsets.l + rx,
+					cy: offsets.t + ry,
+					r:  r
+				};
+				var rColor = new Color(taFontColor);
+				// If we have a radius, we'll need to fade the ring some
+				if(this.opt.innerRadius){
+					rColor.a = 0.1;
+				}
+				var ring = this._createRing(s, circle).setStroke(rColor);
+				if(this.opt.innerRadius){
+					// If we have a radius, fill it with the faded color.
+					ring.setFill(rColor);
+				}
+				if(this.opt.zeroDataMessage){
+					this.renderLabel(s, circle.cx, circle.cy + size/3, this.opt.zeroDataMessage, {
+						series: {
+							font: taFont,
+							fontColor: taFontColor 
+						}
+					},	null, "middle");
+				}
+				this.dyn = [];
+				arr.forEach(run, function(item, i){
+					this.dyn.push({
+						fill: this._plotFill(themes[i].series.fill, dim, offsets),
+						stroke: themes[i].series.stroke});
+				}, this);
+			});
+			/* END Added to handle no data case */
+
+			// Draw over circle!
+			if(!this.run && !this.run.data.ength){
+				noDataFunc();
+				return this;
 			}
-			var	circle = {
-				cx: offsets.l + rx,
-				cy: offsets.t + ry,
-				r:  r
-			};
-
-			// draw shadow
-			if(this.opt.shadow || t.shadow){
-				var shadow = this.opt.shadow || t.shadow;
-				var scircle = lang.clone(circle);
-				scircle.cx += shadow.dx;
-				scircle.cy += shadow.dy;
-				s.createCircle(scircle).setFill(shadow.color).setStroke(shadow);
-			}
-			if(s.setFilter && (this.opt.filter || t.filter)){
-				s.createCircle(circle).setFill(t.series.stroke).setFilter(this.opt.filter || t.filter);
-			}
-
 			if(typeof run[0] == "number"){
 				filteredRun = df.map(run, "x ? Math.max(x, 0) : 0");
 				if(df.every(filteredRun, "<= 0")){
-					s.createCircle(circle).setStroke(t.series.stroke);
-					this.dyn = arr.map(filteredRun, function(){
-						return {  };
-					});
+					noDataFunc();
 					return this;
-				}else{
-					slices = df.map(filteredRun, "/this", df.foldl(filteredRun, "+", 0));
-				 	if(this.opt.labels){
-				 		labels = arr.map(slices, function(x){
-							return x > 0 ? this._getLabel(x * 100) + "%" : "";
-						}, this);
-					}
+				}
+				slices = df.map(filteredRun, "/this", df.foldl(filteredRun, "+", 0));
+				if(this.opt.labels){
+					labels = arr.map(slices, function(x){
+						return x > 0 ? this._getLabel(x * 100) + "%" : "";
+					}, this);
 				}
 			}else{
 				filteredRun = df.map(run, "x ? Math.max(x.y, 0) : 0");
-				if(df.every(filteredRun, "<= 0")){
-					s.createCircle(circle).setStroke(t.series.stroke);
-					this.dyn = arr.map(filteredRun, function(){
-						return {  };
-					});
+				if(!filteredRun.length || df.every(filteredRun, "<= 0")){
+					noDataFunc();
 					return this;
-				}else{
-					slices = df.map(filteredRun, "/this", df.foldl(filteredRun, "+", 0));
-					if(this.opt.labels){
-						labels = arr.map(slices, function(x, i){
-							if(x < 0){ return ""; }
-							var v = run[i];
-							return "text" in v ? v.text : this._getLabel(x * 100) + "%";
-						}, this);
-					}
+				}
+				slices = df.map(filteredRun, "/this", df.foldl(filteredRun, "+", 0));
+				if(this.opt.labels){
+					labels = arr.map(slices, function(x, i){
+						if(x <= 0){ return ""; }
+						var v = run[i];
+						return v.hasOwnProperty("text") ? v.text : this._getLabel(x * 100) + "%";
+					}, this);
 				}
 			}
-			var themes = df.map(run, function(v, i){
+			var themes = df.map(run, function(v){
 				var tMixin = [this.opt, this.run];
 				if(v !== null && typeof v != "number"){
 					tMixin.push(v);
@@ -271,31 +298,123 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 				return t.next("slice", tMixin, true);
 			}, this);
 
-			if(this.opt.labels){
-				size = labelFont ? g.normalizedLength(g.splitFontString(labelFont).size) : 0;
+			if(this.opt.labels) {
 				shift = df.foldl1(df.map(labels, function(label, i){
 					var font = themes[i].series.font;
 					return g._base._getTextBox(label, {font: font}).w;
 				}, this), "Math.max(a, b)") / 2;
+
 				if(this.opt.labelOffset < 0){
 					r = Math.min(rx - 2 * shift, ry - size) + this.opt.labelOffset;
 				}
-				labelR = r - this.opt.labelOffset;
+			}
+			if(this.opt.hasOwnProperty("radius")){
+				r = this.opt.radius < r * 0.9 ? this.opt.radius : r * 0.9;
 			}
 
+			if (this.opt.labels && this.opt.labelStyle == "columns") {
+				r = r / 2;
+				if (rx > ry && rx > r * 2) {
+					r *= rx / (r * 2);
+				}
+				if (r >= ry * 0.8) {
+					r = ry * 0.8;
+				}
+			} else {
+				if (r >= ry * 0.9) {
+					r = ry * 0.9;
+				}
+			}
+
+			labelR = r - this.opt.labelOffset;
+
+			var circle = {
+					cx: offsets.l + rx,
+					cy: offsets.t + ry,
+					r:  r
+				};
+
+			this.dyn = [];
 			// draw slices
 			var eventSeries = new Array(slices.length);
+
+			// Calulate primarily size for each slice
+			var slicesSteps = [], localStart = start;
+			var minWidth = this.opt.minWidth;
+			arr.forEach(slices, function(slice, i){
+				if(slice === 0){
+					slicesSteps[i] = {
+						step: 0,
+						end: localStart,
+						start: localStart,
+						weak: false
+					};
+					return;
+				}
+				var end = localStart + slice * 2 * Math.PI;
+				if(i === slices.length - 1){
+					end = startAngle + 2 * Math.PI;
+				}
+				var step = end - localStart,
+					dist = step * r;
+				slicesSteps[i] = {
+					step:  step,
+					start: localStart,
+					end:   end,
+					weak: dist < minWidth
+				};
+				localStart = end;
+			});
+
+			if(minWidth > 0){
+				var weakCount = 0, weakCoef = minWidth / r, oldWeakCoefSum = 0, i;
+				for(i = slicesSteps.length - 1; i >= 0; i--){
+					if(slicesSteps[i].weak){
+						++weakCount;
+						oldWeakCoefSum += slicesSteps[i].step;
+						slicesSteps[i].step = weakCoef;
+					}
+				}
+				// make sure that our steps are small enough
+				var weakCoefSum = weakCount * weakCoef;
+				if(weakCoefSum > Math.PI){
+					weakCoef = Math.PI / weakCount;
+					for(i = 0; i < slicesSteps.length; ++i){
+						if(slicesSteps[i].weak){
+							slicesSteps[i].step = weakCoef;
+						}
+					}
+					weakCoefSum = Math.PI;
+				}
+				// now let's redistribute percentage
+				if(weakCount > 0){
+					weakCoef = 1 - (weakCoefSum - oldWeakCoefSum) / 2 / Math.PI;
+					for(i = 0; i < slicesSteps.length; ++i){
+						if(!slicesSteps[i].weak){
+							slicesSteps[i].step = weakCoef * slicesSteps[i].step;
+						}
+					}
+				}
+				// now let's update start and end values
+				for(i = 0; i < slicesSteps.length; ++i){
+					slicesSteps[i].start = i ? slicesSteps[i].end : localStart;
+					slicesSteps[i].end = slicesSteps[i].start + slicesSteps[i].step;
+				}
+				// let's make sure that our last end is exactly 2 * Math.PI
+				for(i = slicesSteps.length - 1; i >= 0; --i){
+					if(slicesSteps[i].step !== 0){
+						slicesSteps[i].end = localStart + 2 * Math.PI;
+						break;
+					}
+				}
+			}
+
+			localStart = start;
+			var o, specialFill;
 			arr.some(slices, function(slice, i){
-				if(slice < 0){
-					// degenerated slice
-					return false;	// continue
-				}
-				var v = run[i], theme = themes[i], specialFill, o;
-				if(slice == 0){
-					this.dyn.push({fill: theme.series.fill, stroke: theme.series.stroke});
-					return false;
-				}
-				
+				var shape;
+				var v = run[i], theme = themes[i];
+
 				if(slice >= 1){
 					// whole pie
 					specialFill = this._plotFill(theme.series.fill, dim, offsets);
@@ -305,7 +424,7 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 							width: 2 * circle.r, height: 2 * circle.r
 						});
 					specialFill = this._pseudoRadialFill(specialFill, {x: circle.cx, y: circle.cy}, circle.r);
-					var shape = s.createCircle(circle).setFill(specialFill).setStroke(theme.series.stroke);
+					shape = this._createRing(s, circle).setFill(specialFill).setStroke(theme.series.stroke);
 					this.dyn.push({fill: specialFill, stroke: theme.series.stroke});
 
 					if(events){
@@ -324,62 +443,78 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 						eventSeries[i] = o;
 					}
 
-					return false;	// we continue because we want to collect null data points for legend
+					var k;
+					for(k = i + 1; k < slices.length; k++){
+						theme = themes[k];
+						this.dyn.push({fill: theme.series.fill, stroke: theme.series.stroke});
+					}
+					return true;	// stop iteration
 				}
+
+				if(slicesSteps[i].step === 0){
+					// degenerated slice
+					// But we still want a fill since this will be skipped and we need the fill
+					// for the label.
+					this.dyn.push({fill: theme.series.fill, stroke: theme.series.stroke});
+					return false;	// continue
+				}
+
 				// calculate the geometry of the slice
-				var end = start + slice * 2 * Math.PI;
-				if(i + 1 == slices.length){
-					end = startAngle + 2 * Math.PI;
-				}
-				var	step = end - start,
-					x1 = circle.cx + r * Math.cos(start),
-					y1 = circle.cy + r * Math.sin(start),
-					x2 = circle.cx + r * Math.cos(end),
-					y2 = circle.cy + r * Math.sin(end);
+				var step = slicesSteps[i].step,
+					x1 = circle.cx + r * Math.cos(localStart),
+					y1 = circle.cy + r * Math.sin(localStart),
+					x2 = circle.cx + r * Math.cos(localStart + step),
+					y2 = circle.cy + r * Math.sin(localStart + step);
 				// draw the slice
-				var fanSize = m._degToRad(this.opt.fanSize);
+				var fanSize = m._degToRad(this.opt.fanSize), stroke;
 				if(theme.series.fill && theme.series.fill.type === "radial" && this.opt.radGrad === "fan" && step > fanSize){
 					var group = s.createGroup(), nfans = Math.ceil(step / fanSize), delta = step / nfans;
 					specialFill = this._shapeFill(theme.series.fill,
 						{x: circle.cx - circle.r, y: circle.cy - circle.r, width: 2 * circle.r, height: 2 * circle.r});
-					for(var j = 0; j < nfans; ++j){
-						var fansx = j == 0 ? x1 : circle.cx + r * Math.cos(start + (j - FUDGE_FACTOR) * delta),
-							fansy = j == 0 ? y1 : circle.cy + r * Math.sin(start + (j - FUDGE_FACTOR) * delta),
-							fanex = j == nfans - 1 ? x2 : circle.cx + r * Math.cos(start + (j + 1 + FUDGE_FACTOR) * delta),
-							faney = j == nfans - 1 ? y2 : circle.cy + r * Math.sin(start + (j + 1 + FUDGE_FACTOR) * delta);
-						group.createPath().
-								moveTo(circle.cx, circle.cy).
-								lineTo(fansx, fansy).
-								arcTo(r, r, 0, delta > Math.PI, true, fanex, faney).
-								lineTo(circle.cx, circle.cy).
-								closePath().
-								setFill(this._pseudoRadialFill(specialFill, {x: circle.cx, y: circle.cy}, r, start + (j + 0.5) * delta, start + (j + 0.5) * delta));
+					var j, alpha, beta, fansx, fansy, fanex, faney;
+					for(j = 0; j < nfans; ++j){
+						alpha = localStart + (j - FUDGE_FACTOR) * delta;
+						beta  = localStart + (j + 1 + FUDGE_FACTOR) * delta;
+						fansx = j == 0 ? x1 : circle.cx + r * Math.cos(alpha);
+						fansy = j == 0 ? y1 : circle.cy + r * Math.sin(alpha);
+						fanex = j == nfans - 1 ? x2 : circle.cx + r * Math.cos(beta);
+						faney = j == nfans - 1 ? y2 : circle.cy + r * Math.sin(beta);
+						this._createSlice(group, circle, r, fansx, fansy, fanex, faney, alpha, delta).
+							setFill(this._pseudoRadialFill(specialFill, {x: circle.cx, y: circle.cy}, r,
+								localStart + (j + 0.5) * delta, localStart + (j + 0.5) * delta));
 					}
-					group.createPath().
-						moveTo(circle.cx, circle.cy).
-						lineTo(x1, y1).
-						arcTo(r, r, 0, step > Math.PI, true, x2, y2).
-						lineTo(circle.cx, circle.cy).
-						closePath().
-						setStroke(theme.series.stroke);
+					stroke = theme.series.stroke;
+					this._createSlice(group, circle, r, x1, y1, x2, y2, localStart, step).setStroke(stroke);
 					shape = group;
 				}else{
-					shape = s.createPath().
-						moveTo(circle.cx, circle.cy).
-						lineTo(x1, y1).
-						arcTo(r, r, 0, step > Math.PI, true, x2, y2).
-						lineTo(circle.cx, circle.cy).
-						closePath().
-						setStroke(theme.series.stroke);
+					stroke = theme.series.stroke;
+
+					shape = this._createSlice(s, circle, r, x1, y1, x2, y2, localStart, step).setStroke(stroke);
+
 					specialFill = theme.series.fill;
 					if(specialFill && specialFill.type === "radial"){
 						specialFill = this._shapeFill(specialFill, {x: circle.cx - circle.r, y: circle.cy - circle.r, width: 2 * circle.r, height: 2 * circle.r});
 						if(this.opt.radGrad === "linear"){
-							specialFill = this._pseudoRadialFill(specialFill, {x: circle.cx, y: circle.cy}, r, start, end);
+							specialFill = this._pseudoRadialFill(specialFill, {x: circle.cx, y: circle.cy}, r, localStart, localStart + step);
 						}
 					}else if(specialFill && specialFill.type === "linear"){
+						var bbox = lang.clone(shape.getBoundingBox());
+						if(g.renderer === "svg"){
+							// Try to fix the bounding box calculations for
+							// height.  Only really works for SVG.
+							var pos = {w: 0, h: 0};
+							try{
+								pos = domGeom.position(shape.rawNode);
+							}catch(ignore){}
+							if(pos.h > bbox.height){
+								bbox.height = pos.h;
+							}
+							if(pos.w > bbox.width){
+								bbox.width = pos.w;
+							}
+						}
 						specialFill = this._plotFill(specialFill, dim, offsets);
-						specialFill = this._shapeFill(specialFill, shape.getBoundingBox());
+						specialFill = this._shapeFill(specialFill, bbox);
 					}
 					shape.setFill(specialFill);
 				}
@@ -401,17 +536,18 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 					eventSeries[i] = o;
 				}
 
-				start = end;
+				localStart = localStart + step;
 
 				return false;	// continue
 			}, this);
 			// draw labels
 			if(this.opt.labels){
-				var isRtl = has("dojo-bidi") && this.chart.isRightToLeft(); 
-				if(this.opt.labelStyle == "default"){ // inside or outside based on labelOffset
+				var isRtl = has("dojo-bidi") && this.chart.isRightToLeft();
+				if(this.opt.labelStyle == "default"){
 					start = startAngle;
+					localStart = start;
 					arr.some(slices, function(slice, i){
-						if(slice <= 0){
+						if(slice <= 0 && !this.opt.minWidth){
 							// degenerated slice
 							return false;	// continue
 						}
@@ -426,58 +562,124 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 						if(i + 1 == slices.length){
 							end = startAngle + 2 * Math.PI;
 						}
+
 						if(this.opt.omitLabels && end-start < 0.001){
 							return false;	// continue
 						}
-						var	labelAngle = (start + end) / 2,
+
+						var labelAngle = localStart + (slicesSteps[i].step / 2),//(start + end) / 2,
 							x = circle.cx + labelR * Math.cos(labelAngle),
 							y = circle.cy + labelR * Math.sin(labelAngle) + size / 2;
 						// draw the label
 						this.renderLabel(s, isRtl ? dim.width - x : x, y, labels[i], theme, this.opt.labelOffset > 0);
+						localStart += slicesSteps[i].step;
 						start = end;
 						return false;	// continue
 					}, this);
 				}else if(this.opt.labelStyle == "columns"){
-					start = startAngle;
-					var omitLabels = this.opt.omitLabels;
 					//calculate label angles
-					var labeledSlices = [];
+					var omitLabels = this.opt.omitLabels;
+					start = startAngle;
+					localStart = start;
+					var labeledSlices = [],
+						significantCount = 0, k;
+					for(k = slices.length - 1; k >= 0; --k){
+						if(slices[k]){
+							++significantCount;
+						}
+					}
 					arr.forEach(slices, function(slice, i){
 						var end = start + slice * 2 * Math.PI;
 						if(i + 1 == slices.length){
 							end = startAngle + 2 * Math.PI;
 						}
-						var labelAngle = (start + end) / 2;
-						labeledSlices.push({
-							angle: labelAngle,
-							left: Math.cos(labelAngle) < 0,
-							theme: themes[i],
-							index: i,
-							omit: omitLabels?end - start < 0.001:false
-						});
-						start = end;
-					});
-					//calculate label radius to each slice
-					var labelHeight = g._base._getTextBox("a",{ font: labelFont }).h;
-					this._getProperLabelRadius(labeledSlices, labelHeight, circle.r * 1.1);
-					//draw label and wiring
-					arr.forEach(labeledSlices, function(slice, i){
-						if(!slice.omit){
-							var leftColumn = circle.cx - circle.r * 2,
-								rightColumn = circle.cx + circle.r * 2,
-								labelWidth = g._base._getTextBox(labels[i], {font: slice.theme.series.font}).w,
-								x = circle.cx + slice.labelR * Math.cos(slice.angle),
-								y = circle.cy + slice.labelR * Math.sin(slice.angle),
-								jointX = (slice.left) ? (leftColumn + labelWidth) : (rightColumn - labelWidth),
-								labelX = (slice.left) ? leftColumn : jointX;
-							var wiring = s.createPath().moveTo(circle.cx + circle.r * Math.cos(slice.angle), circle.cy + circle.r * Math.sin(slice.angle));
-							if(Math.abs(slice.labelR * Math.cos(slice.angle)) < circle.r * 2 - labelWidth){
-								wiring.lineTo(x, y);
+						if(this.minWidth === 0 ? end - start >= 0.001 : slice !== 0){
+							// var labelAngle = (start + end) / 2;
+							var labelAngle = localStart + (slicesSteps[i].step / 2);//(start + end) / 2,
+							if(significantCount === 1 && !this.opt.minWidth){
+								labelAngle = (start + end) / 2;
 							}
-							wiring.lineTo(jointX, y).setStroke(slice.theme.series.labelWiring);
-							this.renderLabel(s, isRtl ? dim.width - labelWidth - labelX : labelX, y, labels[i], slice.theme, false, "left");
+							labeledSlices.push({
+								angle: labelAngle,
+								left:  Math.cos(labelAngle) < 0,
+								theme: themes[i],
+								index: i,
+								omit: omitLabels? end - start < 0.001:false
+							});
 						}
-					},this);
+						start = end;
+						localStart += slicesSteps[i].step;
+					}, this);
+
+					//calculate label radius to each slice
+					var labelHeight = g._base._getTextBox("a", {font:taFont, whiteSpace: "nowrap"}).h;
+					this._getProperLabelRadius(labeledSlices, labelHeight, circle.r * 1.1);
+
+					//draw label and wiring
+					var leftColumn  = circle.cx - circle.r * 2,
+						rightColumn = circle.cx + circle.r * 2;
+					arr.forEach(labeledSlices, function(slice){
+						if(slice.omit){
+							return;
+						}
+						var cTheme = themes[slice.index], lrPadding = 0;
+						if(cTheme && cTheme.axis && cTheme.axis.tick && cTheme.axis.tick.labelGap){
+							// Try to pad the lable a bit, the same as a tick gap.
+							lrPadding = cTheme.axis.tick.labelGap;
+						}
+						var labelWidth = g._base._getTextBox(labels[slice.index],
+								{font: cTheme.series.font, whiteSpace: "nowrap", paddingLeft: lrPadding + "px"}).w,
+							x = circle.cx + slice.labelR * Math.cos(slice.angle),
+							y = circle.cy + slice.labelR * Math.sin(slice.angle),
+							jointX = (slice.left) ? (leftColumn + labelWidth) : (rightColumn - labelWidth),
+							labelX = (slice.left) ? leftColumn : jointX + lrPadding,
+							newRadius = circle.r,
+							wiring = s.createPath().moveTo(circle.cx + newRadius * Math.cos(slice.angle),
+								circle.cy + newRadius * Math.sin(slice.angle));
+						if(Math.abs(slice.labelR * Math.cos(slice.angle)) < circle.r * 2 - labelWidth){
+							wiring.lineTo(x, y);
+						}
+						wiring.lineTo(jointX, y).setStroke(slice.theme.series.labelWiring);
+						// Push the wiring to the back so that highlight/magnify actions don't bleed the wire.
+						wiring.moveToBack();
+						// Try to adjust the wiring position here.  The browser always adds a bit
+						// of padding on height, so divide by 3 instead of 2.
+						var mid = labelHeight/3 + y;
+						var elem = this.renderLabel(s, labelX, mid || 0, labels[slice.index], cTheme, false, "left");
+
+						if(events && !this.opt.htmlLabels){
+							var fontWidth  = g._base._getTextBox(labels[slice.index], {font: slice.theme.series.font}).w || 0,
+								fontHeight = g.normalizedLength(g.splitFontString(slice.theme.series.font).size);
+							o = {
+								element: "labels",
+								index:   slice.index,
+								run:     this.run,
+								shape:   elem,
+								x:       labelX,
+								y:       y,
+								label:   labels[slice.index]
+							};
+
+							var shp = elem.getShape(),
+								lt = domGeom.position(this.chart.node, true),
+								aroundRect = lang.mixin({ type : 'rect' }, {
+									x: shp.x,
+									y: shp.y - 2 * fontHeight
+								});
+
+							aroundRect.x += lt.x;
+							aroundRect.y += lt.y;
+							aroundRect.x = Math.round(aroundRect.x);
+							aroundRect.y = Math.round(aroundRect.y);
+							aroundRect.width  = Math.ceil(fontWidth);
+							aroundRect.height = Math.ceil(fontHeight);
+
+							o.aroundRect = aroundRect;
+
+							this._connectEvents(o);
+							eventSeries[slices.length + slice.index] = o;
+						}
+					}, this);
 				}
 			}
 			// post-process events to restore the original indexing
@@ -485,63 +687,115 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare",
 			this._eventSeries[this.run.name] = df.map(run, function(v){
 				return v <= 0 ? null : eventSeries[esi++];
 			});
+
 			// chart mirroring starts
 			if(has("dojo-bidi")){
 				this._checkOrientation(this.group, dim, offsets);
 			}
-			// chart mirroring ends
+
 			return this;	//	dojox/charting/plot2d/Pie
 		},
-		_getProperLabelRadius: function(slices, labelHeight, minRidius){
-			var leftCenterSlice, rightCenterSlice,
-				leftMinSIN = 1, rightMinSIN = 1;
+
+		_getProperLabelRadius: function(slices, labelHeight, minRadius){
 			if(slices.length == 1){
-				slices[0].labelR = minRidius;
+				slices[0].labelR = minRadius;
 				return;
 			}
-			for(var i = 0; i < slices.length; i++){
-				var tempSIN = Math.abs(Math.sin(slices[i].angle));
+			var leftCenterSlice = {}, rightCenterSlice = {}, leftMinSIN = 2, rightMinSIN = 2, i;
+			var tempSIN;
+			for(i = 0; i < slices.length; ++i){
+				tempSIN = Math.abs(Math.sin(slices[i].angle));
 				if(slices[i].left){
-					if(leftMinSIN >= tempSIN){
+					if(leftMinSIN > tempSIN){
 						leftMinSIN = tempSIN;
 						leftCenterSlice = slices[i];
 					}
 				}else{
-					if(rightMinSIN >= tempSIN){
+					if(rightMinSIN > tempSIN){
 						rightMinSIN = tempSIN;
 						rightCenterSlice = slices[i];
 					}
 				}
 			}
-			leftCenterSlice.labelR = rightCenterSlice.labelR = minRidius;
-			this._calculateLabelR(leftCenterSlice, slices, labelHeight);
-			this._calculateLabelR(rightCenterSlice, slices, labelHeight);
+			leftCenterSlice.labelR = rightCenterSlice.labelR = minRadius;
+			this._caculateLabelR(leftCenterSlice,  slices, labelHeight);
+			this._caculateLabelR(rightCenterSlice, slices, labelHeight);
 		},
-		_calculateLabelR: function(firstSlice, slices, labelHeight){
-			var i = firstSlice.index,length = slices.length,
-				currentLabelR = firstSlice.labelR, nextLabelR;
-			while(!(slices[i%length].left ^ slices[(i+1)%length].left)){
-				if(!slices[(i + 1) % length].omit){
-					nextLabelR = (Math.sin(slices[i % length].angle) * currentLabelR + ((slices[i % length].left) ? (-labelHeight) : labelHeight)) /
-					Math.sin(slices[(i + 1) % length].angle);
-					currentLabelR = (nextLabelR < firstSlice.labelR) ? firstSlice.labelR : nextLabelR;
-					slices[(i + 1) % length].labelR = currentLabelR;
-				}
-				i++;
+
+		_caculateLabelR: function(firstSlice, slices, labelHeight){
+			var i, j, k, length = slices.length, currentLabelR = firstSlice.labelR, nextLabelR,
+				step = slices[firstSlice.index].left ? -labelHeight : labelHeight;
+			for(k = 0, i = firstSlice.index, j = (i + 1) % length; k < length && slices[i].left === slices[j].left; ++k){
+				nextLabelR = (Math.sin(slices[i].angle) * currentLabelR + step) / Math.sin(slices[j].angle);
+				currentLabelR = Math.max(firstSlice.labelR, nextLabelR);
+				slices[j].labelR = currentLabelR;
+				i = (i + 1) % length;
+				j = (j + 1) % length;
 			}
-			i = firstSlice.index;
-			var j = (i == 0)?length-1 : i - 1;
-			while(!(slices[i].left ^ slices[j].left)){
-				if(!slices[j].omit){
-					nextLabelR = (Math.sin(slices[i].angle) * currentLabelR + ((slices[i].left) ? labelHeight : (-labelHeight))) /
-					Math.sin(slices[j].angle);
-					currentLabelR = (nextLabelR < firstSlice.labelR) ? firstSlice.labelR : nextLabelR;
-					slices[j].labelR = currentLabelR;
-				}
-				i--;j--;
-				i = (i < 0)?i+slices.length:i;
-				j = (j < 0)?j+slices.length:j;
+			if(k >= length){
+				slices[0].labelR = firstSlice.labelR;
 			}
+			for(k = 0, i = firstSlice.index, j = (i || length) - 1; k < length && slices[i].left === slices[j].left; ++k){
+				nextLabelR = (Math.sin(slices[i].angle) * currentLabelR - step) / Math.sin(slices[j].angle);
+				currentLabelR = Math.max(firstSlice.labelR, nextLabelR);
+				slices[j].labelR = currentLabelR;
+				i = (i || length) - 1;
+				j = (j || length) - 1;
+			}
+		},
+
+		_createRing: function(group, circle){
+			var r = this.opt.innerRadius;
+			if(r > 0){
+				// Percentage, use circle.  Anything < 0 for innerRadius
+				// is assumed to be a multiple of the radius.  So 0.25 innerRadius value
+				// is computed to be 25% of the outer radius.
+				r = circle.r * (r/100);
+			}else if(r < 0){
+				r = -r; // Assume it is pixels, fixed size hole.
+			}
+			if(r){
+				return group.createPath({}).setAbsoluteMode(true).
+					moveTo(circle.cx, circle.cy - circle.r).
+					arcTo(circle.r, circle.r, 0, false, true, circle.cx + circle.r, circle.cy).
+					arcTo(circle.r, circle.r, 0,  true, true, circle.cx, circle.cy - circle.r).
+					closePath().
+					moveTo(circle.cx, circle.cy - r).
+					arcTo(r, r, 0, false, true, circle.cx + r, circle.cy).
+					arcTo(r, r, 0,  true, true, circle.cx, circle.cy - r).
+					closePath();
+			}
+			return group.createCircle(circle);
+		},
+		_createSlice: function(group, circle, R, x1, y1, x2, y2, fromAngle, stepAngle){
+			var r = this.opt.innerRadius;
+			if(r > 0){
+				// Percentage, use circle.  Anything < 0 for innerRadius
+				// is assumed to be a multiple of the radius.  So 0.25 innerRadius value
+				// is computed to be 25% of the outer radius.
+				r = circle.r * (r/100);
+			}else if(r < 0){
+				r = -r; // Assume it is pixels, fixed size hole.
+			}
+			if(r){
+				var innerX1 = circle.cx + r * Math.cos(fromAngle),
+					innerY1 = circle.cy + r * Math.sin(fromAngle),
+					innerX2 = circle.cx + r * Math.cos(fromAngle + stepAngle),
+					innerY2 = circle.cy + r * Math.sin(fromAngle + stepAngle);
+				return group.createPath({}).setAbsoluteMode(true).
+					moveTo(innerX1, innerY1).
+					lineTo(x1, y1).
+					arcTo(R, R, 0, stepAngle > Math.PI, true, x2, y2).
+					lineTo(innerX2, innerY2).
+					arcTo(r, r, 0, stepAngle > Math.PI, false, innerX1, innerY1).
+					closePath();
+			}
+			return group.createPath({}).setAbsoluteMode(true).
+				moveTo(circle.cx, circle.cy).
+				lineTo(x1, y1).
+				arcTo(R, R, 0, stepAngle > Math.PI, true, x2, y2).
+				lineTo(circle.cx, circle.cy).
+				closePath();
 		}
 	});
 });

--- a/charting/tests/BidiSupport/bidi_Pie_smart_label.html
+++ b/charting/tests/BidiSupport/bidi_Pie_smart_label.html
@@ -25,132 +25,134 @@
         <script type="text/javascript" src="../../../../dojo/dojo.js" data-dojo-config="parseOnLoad:true, has:{'dojo-bidi': true}">
         </script>
         <script type="text/javascript">
- 			dojo.require("dojo.parser");
-			dojo.require("doh.runner");
+ 				dojo.require("dojo.parser");
+ 				dojo.require("doh.runner");
 
-			dojo.require("dojox.charting.Chart");
-            dojo.require("dojox.charting.plot2d.Pie");
-            dojo.require("dojox.charting.action2d.Highlight");
-            dojo.require("dojox.charting.action2d.MoveSlice");
-            dojo.require("dojox.charting.action2d.Tooltip");
-			dojo.require("dojox.charting.themes.Tom");
-            dojo.require("dojox.charting.widget.Legend");
-			
-            var pieChart = null;
-			var legend = null;
-            dojo.addOnLoad(function(){
-                var dc = dojox.charting;
-                pieChart = new dc.Chart("pieChart", {textDir:"rtl"});
-                pieChart.setTheme(dc.themes.Tom).addPlot("default", {
-                    type: "Pie",
-                    font: "normal normal 10pt Tahoma",
-					fontColor: "#ccc",
-					labelWiring: "#ccc",
-                    radius: 100,
-					labelStyle: "columns",
-					htmlLabels: true,
-					startAngle: -10
-                }).addSeries("Series A", [{
-                    y: 12.1,
-                    text: "The country is \u05e1\u05d9\u05df.",
-                    tooltip: "1,210 \u05de\u05dc\u05d9\u05d5\u05df."
-                },{
-                    y: 9.52,
-                    text: "\u05d4\u05de\u05d3\u05d9\u05e0\u05d4\u0020\u05d4\u05d9\u05d0 India.",
-                    tooltip: "952 million."
-                }, {
-                    y: 2.66,
-                    text: "\u05d0\u05e8\u05d4\u0022\u05d1.",
-                    tooltip: "266 \u05de\u05dc\u05d9\u05d5\u05df."
-                }, {
-                    y: 2.06,
-                    text: "Indonisia.",
-                    tooltip: "206 million."
-                }, {
-                    y: 1.63,
-                    text: "Brazil.",
-                    tooltip: "163 million."
-                },{
-                    y: 1.48,
-                    text: "Russian.",
-                    tooltip: "148 million."
-                },{
-                    y: 1.29,
-                    text: "Pakistan.",
-                    tooltip: "129 million."
-                },{
-                    y: 1.25,
-                    text: "Japan.",
-                    tooltip: "125 million."
-                },{
-                    y: 1.23,
-                    text: "Bangladesh.",
-                    tooltip: "123 million."
-                },{
-                    y: 1.04,
-                    text: "Nigeria.",
-                    tooltip: "104 million."
-                },{
-                    y: 0.96,
-                    text: "Mexico.",
-                    tooltip: "96 million."
-                },{
-                    y: 0.84,
-                    text: "Germany.",
-                    tooltip: "84 million."
-                },{
-                    y: 0.74,
-                    text: "Phillippines.",
-                    tooltip: "74 million."
-                },{
-                    y: 0.74,
-                    text: "Viet Nam.",
-                    tooltip: "74 million."
-                },{
-                    y: 0.66,
-                    text: "Iran.",
-                    tooltip: "66 million."
-                },{
-                    y: 0.64,
-                    text: "Egypt.",
-                    tooltip: "64 million."
-				}]);
-				var anim_b = new dc.action2d.Highlight(pieChart, "default");
-				var anim_c = new dc.action2d.Tooltip(pieChart, "default");
-				pieChart.render();
-				legend = new dojox.charting.widget.Legend({
-					chart: pieChart,
-					horizontal:false
-				}, "legend");
+ 				dojo.require("dojox.charting.Chart");
+ 				dojo.require("dojox.charting.plot2d.Pie");
+ 				dojo.require("dojox.charting.action2d.Highlight");
+ 				dojo.require("dojox.charting.action2d.MoveSlice");
+ 				dojo.require("dojox.charting.action2d.Tooltip");
+ 				dojo.require("dojox.charting.themes.Tom");
+ 				dojo.require("dojox.charting.widget.Legend");
 
-				doh.register("parse", function(){
-					dojo.parser.parse();
-				});
+ 				var pieChart = null;
+ 				var legend = null;
+ 				dojo.addOnLoad(function () {
+ 					var dc = dojox.charting;
+ 					pieChart = new dc.Chart("pieChart", {
+ 						textDir: "rtl"
+ 					});
+ 					pieChart.setTheme(dc.themes.Tom).addPlot("default", {
+ 						type: "Pie",
+ 						font: "normal normal 10pt Tahoma",
+ 						fontColor: "#ccc",
+ 						labelWiring: "#ccc",
+ 						labelStyle: "columns",
+ 						htmlLabels: true,
+ 						startAngle: -10
+ 					}).addSeries("Series A", [{
+ 						y: 12.1,
+ 						text: "The country is \u05e1\u05d9\u05df.",
+ 						tooltip: "1,210 \u05de\u05dc\u05d9\u05d5\u05df."
+ 					}, {
+ 						y: 9.52,
+ 						text: "\u05d4\u05de\u05d3\u05d9\u05e0\u05d4\u0020\u05d4\u05d9\u05d0 India.",
+ 						tooltip: "952 million."
+ 					}, {
+ 						y: 2.66,
+ 						text: "\u05d0\u05e8\u05d4\u0022\u05d1.",
+ 						tooltip: "266 \u05de\u05dc\u05d9\u05d5\u05df."
+ 					}, {
+ 						y: 2.06,
+ 						text: "Indonisia.",
+ 						tooltip: "206 million."
+ 					}, {
+ 						y: 1.63,
+ 						text: "Brazil.",
+ 						tooltip: "163 million."
+ 					}, {
+ 						y: 1.48,
+ 						text: "Russian.",
+ 						tooltip: "148 million."
+ 					}, {
+ 						y: 1.29,
+ 						text: "Pakistan.",
+ 						tooltip: "129 million."
+ 					}, {
+ 						y: 1.25,
+ 						text: "Japan.",
+ 						tooltip: "125 million."
+ 					}, {
+ 						y: 1.23,
+ 						text: "Bangladesh.",
+ 						tooltip: "123 million."
+ 					}, {
+ 						y: 1.04,
+ 						text: "Nigeria.",
+ 						tooltip: "104 million."
+ 					}, {
+ 						y: 0.96,
+ 						text: "Mexico.",
+ 						tooltip: "96 million."
+ 					}, {
+ 						y: 0.84,
+ 						text: "Germany.",
+ 						tooltip: "84 million."
+ 					}, {
+ 						y: 0.74,
+ 						text: "Phillippines.",
+ 						tooltip: "74 million."
+ 					}, {
+ 						y: 0.74,
+ 						text: "Viet Nam.",
+ 						tooltip: "74 million."
+ 					}, {
+ 						y: 0.66,
+ 						text: "Iran.",
+ 						tooltip: "66 million."
+ 					}, {
+ 						y: 0.64,
+ 						text: "Egypt.",
+ 						tooltip: "64 million."
+ 					}]);
+ 					var anim_b = new dc.action2d.Highlight(pieChart, "default");
+ 					var anim_c = new dc.action2d.Tooltip(pieChart, "default");
+ 					pieChart.render();
+ 					legend = new dojox.charting.widget.Legend({
+ 						chart: pieChart,
+ 						horizontal: false
+ 					}, "legend");
 
-				doh.register("test textDir", [
-					{
-						name: "Pies textDir",
+ 					doh.register("parse", function () {
+ 						dojo.parser.parse();
+ 					});
 
-						runTest: function(){
-							doh.is("rtl", pieChart.textDir, "pieChart: internal labels");
-							doh.is("rtl", legend.textDir, "legend: external labels");
-						}
-					}	
-				]);		
-				
-				doh.run();
-				
-			});
-			function refreshChart(){
-				var newData = [];
-				for(var i = 0; i < 16; i++){
-					newData.push(Math.random()*10);
-				}
-				newData.sort(function(v1,v2){return v2 - v1});
-				pieChart.updateSeries("Series A", newData);
-				pieChart.render();
-				legend.refresh();
-			}
+ 					doh.register("test textDir", [{
+ 						name: "Pies textDir",
+
+ 						runTest: function () {
+ 							doh.is("rtl", pieChart.textDir, "pieChart: internal labels");
+ 							doh.is("rtl", legend.textDir, "legend: external labels");
+ 						}
+ 					}]);
+
+ 					doh.run();
+
+ 				});
+
+ 				function refreshChart() {
+ 					var newData = [];
+ 					for (var i = 0; i < 16; i++) {
+ 						newData.push(Math.random() * 10);
+ 					}
+ 					newData.sort(function (v1, v2) {
+ 						return v2 - v1
+ 					});
+ 					pieChart.updateSeries("Series A", newData);
+ 					pieChart.render();
+ 					legend.refresh();
+ 				}
         </script>
     </head>
     <body class="claro">

--- a/charting/tests/test_pie2d.html
+++ b/charting/tests/test_pie2d.html
@@ -1,217 +1,256 @@
-<!--[if IE 7]>
-<!DOCTYPE>
-<html lang="en">
-	<head>
-<![endif]-->
-<!--[if IE 8]>
-<!DOCTYPE>
-<html lang="en">
-    <head>
-           <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7"/>
-<![endif]-->
-<![if gte IE 9]>
 <!DOCTYPE HTML>
-<html lang="en">
+<html>
 	<head>
-<![endif]>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Pie 2D</title>
-<style type="text/css">
-	@import "../../../dojo/resources/dojo.css";
-	@import "../../../dijit/tests/css/dijitTests.css";
-</style>
-<script type="text/javascript" src="../../../dojo/dojo.js" data-dojo-config="isDebug: true"></script>
-<script type="text/javascript">
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<title>Pie 2D</title>
+		<style type="text/css">
+			@import "../../../dojo/resources/dojo.css";
+			@import "../../../dijit/tests/css/dijitTests.css";
+		</style>
+		<script type="text/javascript" src="../../../dojo/dojo.js" data-dojo-config="isDebug: true, async: true"></script>
+		<script type="text/javascript">
+			require([
+				"dojox/charting/Chart",
+				"dojox/charting/plot2d/Pie",
+				"dojox/charting/themes/PlotKit/blue",
+				"dojox/charting/themes/PlotKit/green",
+				"dojox/charting/themes/PlotKit/red",
+				"dojox/charting/themes/Adobebricks",
+				"dojox/charting/themes/Algae",
+				"dojox/charting/themes/Claro",
+				"dojo/domReady!"
+			], function(Chart, Pie, pkBlue, pkGreen, pkRed, Adobebricks, Algae, Claro){
+				var chart1 = new Chart("test1");
+				chart1.setTheme(pkBlue);
+				chart1.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "white",
+					labelOffset: 40
+				});
+				chart1.addSeries("Series A", [4, 2, 1, 1]);
+				chart1.render();
 
-dojo.require("dojox.charting.Chart");
-dojo.require("dojox.charting.plot2d.Pie");
-dojo.require("dojox.charting.themes.PlotKit.blue");
-dojo.require("dojox.charting.themes.PlotKit.green");
-dojo.require("dojox.charting.themes.PlotKit.red");
-dojo.require("dojox.charting.themes.Adobebricks");
-dojo.require("dojox.charting.themes.Algae");
-dojo.require("dojox.charting.themes.Claro");
+				var chart2 = new Chart("test2");
+				chart2.setTheme(pkBlue);
+				chart2.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "black",
+					labelOffset: -25,
+					precision: 0
+				});
+				chart2.addSeries("Series A", [4, 2, 1, 1]);
+				chart2.render();
 
-makeObjects = function(){
-	var chart1 = new dojox.charting.Chart("test1");
-	chart1.setTheme(dojox.charting.themes.PlotKit.blue);
-	chart1.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
-		labelOffset: 40
-	});
-	chart1.addSeries("Series A", [4, 2, 1, 1]);
-	chart1.render();
+				var chart3 = new Chart("test3");
+				chart3.setTheme(pkGreen);
+				chart3.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 10pt Tahoma",
+					fontColor: "white",
+					labelOffset: 25,
+					radius: 90
+				});
+				chart3.addSeries("Series A", [4, 2, 1, 1]);
+				chart3.render();
 
-	var chart2 = new dojox.charting.Chart("test2");
-	chart2.setTheme(dojox.charting.themes.PlotKit.blue);
-	chart2.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "black",
-		labelOffset: -25,
-		precision: 0
-	});
-	chart2.addSeries("Series A", [4, 2, 1, 1]);
-	chart2.render();
+				var chart4 = new Chart("test4");
+				chart4.setTheme(pkGreen);
+				chart4.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 10pt Tahoma",
+					fontColor: "black",
+					labelOffset: -25,
+					radius: 90
+				});
+				chart4.addSeries("Series A", [4, 2, 1, 1]);
+				chart4.render();
 
-	var chart3 = new dojox.charting.Chart("test3");
-	chart3.setTheme(dojox.charting.themes.PlotKit.green);
-	chart3.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 10pt Tahoma",
-		fontColor: "white",
-		labelOffset: 25,
-		radius: 90
-	});
-	chart3.addSeries("Series A", [4, 2, 1, 1]);
-	chart3.render();
+				var chart5 = new Chart("test5");
+				chart5.setTheme(pkRed);
+				chart5.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 14pt Tahoma",
+					fontColor: "white",
+					labelOffset: 40
+				});
+				chart5.addSeries("Series A", [{
+					y: 4,
+					text: "Red"
+				}, {
+					y: 2,
+					text: "Green"
+				}, {
+					y: 1,
+					text: "Blue"
+				}, {
+					y: 1,
+					text: "Other"
+				}]);
+				chart5.render();
 
-	var chart4 = new dojox.charting.Chart("test4");
-	chart4.setTheme(dojox.charting.themes.PlotKit.green);
-	chart4.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 10pt Tahoma",
-		fontColor: "black",
-		labelOffset: -25,
-		radius: 90
-	});
-	chart4.addSeries("Series A", [4, 2, 1, 1]);
-	chart4.render();
+				var chart6 = new Chart("test6");
+				chart6.setTheme(pkRed);
+				chart6.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 14pt Tahoma",
+					fontColor: "black",
+					labelOffset: 40,
+					startAngle: -45
+				});
+				chart6.addSeries("Series A", [{
+					y: 4,
+					text: "Red",
+					color: "red"
+				}, {
+					y: 2,
+					text: "Green",
+					color: "green"
+				}, {
+					y: 1,
+					text: "Blue",
+					color: "blue"
+				}, {
+					y: 1,
+					text: "Other",
+					color: "white",
+					fontColor: "black"
+				}]);
+				chart6.render();
 
-	var chart5 = new dojox.charting.Chart("test5");
-	chart5.setTheme(dojox.charting.themes.PlotKit.red);
-	chart5.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 14pt Tahoma",
-		fontColor: "white",
-		labelOffset: 40
-	});
-	chart5.addSeries("Series A", [{y: 4, text: "Red"}, {y: 2, text: "Green"}, {y: 1, text: "Blue"}, {y: 1, text: "Other"}]);
-	chart5.render();
+				var chart7 = new Chart("test7");
+				chart7.setTheme(Adobebricks);
+				chart7.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "white",
+					radius: 80
+				});
+				chart7.addSeries("Series A", [4]);
+				chart7.render();
 
-	var chart6 = new dojox.charting.Chart("test6");
-	chart6.setTheme(dojox.charting.themes.PlotKit.red);
-	chart6.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 14pt Tahoma",
-		fontColor: "white",
-		labelOffset: 40,
-		startAngle: -45
-	});
-	chart6.addSeries("Series A", [
-		{y: 4, text: "Red", color: "red"},
-		{y: 2, text: "Green", color: "green"},
-		{y: 1, text: "Blue", color: "blue"},
-		{y: 1, text: "Other", color: "white", fontColor: "black"}
-	]);
-	chart6.render();
+				var chart8 = new Chart("test8");
+				chart8.setTheme(Algae);
+				chart8.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "white",
+					radius: 80
+				});
+				chart8.addSeries("Series A", [{
+					y: -1,
+					text: "Red",
+					color: "red"
+				}, {
+					y: 5,
+					text: "Green",
+					color: "green"
+				}, {
+					y: 0,
+					text: "Blue",
+					color: "blue"
+				}, {
+					y: 0,
+					text: "Other",
+					color: "white",
+					fontColor: "black"
+				}]);
+				chart8.render();
 
-	var chart7 = new dojox.charting.Chart("test7");
-	chart7.setTheme(dojox.charting.themes.Adobebricks);
-	chart7.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
-		radius: 80
-	});
-	chart7.addSeries("Series A", [4]);
-	chart7.render();
+				var chart9 = new Chart("test9");
+				chart9.setTheme(Claro);
+				chart9.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "white",
+					radius: 80
+				});
+				chart9.addSeries("Series A", []);
+				chart9.render();
+				
+				var chart10 = new Chart("test10");
+				chart10.setTheme(Claro);
+				chart10.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "white",
+					radius: 80,
+					zeroDataMessage: "No Non-Zero Data"
+				});
+				chart10.addSeries("Series A", []);
+				chart10.render();
 
-	var chart8 = new dojox.charting.Chart("test8");
-	chart8.setTheme(dojox.charting.themes.Algae);
-	chart8.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
-		radius: 80
-	});
-	chart8.addSeries("Series A", [
-		{y: -1, text: "Red", color: "red"},
-		{y: 5, text: "Green", color: "green"},
-		{y: 0, text: "Blue", color: "blue"},
-		{y: 0, text: "Other", color: "white", fontColor: "black"}
-	]);
-	chart8.render();
-
-	var chart9 = new dojox.charting.Chart("test9");
-	chart9.setTheme(dojox.charting.themes.Claro);
-	chart9.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
-		radius: 80
-	});
-	chart9.addSeries("Series A", []);
-	chart9.render();
-
-	var chart10 = new dojox.charting.Chart("test10");
-	chart10.setTheme(dojox.charting.themes.Claro);
-	chart10.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
-		radius: 80
-	});
-	chart10.addSeries("Series A", [
-		{y: 0, text: "Red", color: "red"},
-		{y: 0, text: "Green", color: "green"},
-		{y: 0, text: "Blue", color: "blue"},
-		{y: 0, text: "Other", color: "white", fontColor: "black"}
-	]);
-	chart10.render();
-
-
-	var chart11 = new dojox.charting.Chart("test11");
-	chart11.setTheme(dojox.charting.themes.Claro);
-	chart11.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
-		radius: 80,
-		zeroDataMessage: "No Non-Zero Data"
-	});
-	chart11.addSeries("Series A", [
-		{y: 0, text: "Red", color: "red"},
-		{y: 0, text: "Green", color: "green"},
-		{y: 0, text: "Blue", color: "blue"},
-		{y: 0, text: "Other", color: "white", fontColor: "black"}
-	]);
-	chart11.render();
-};
-
-dojo.addOnLoad(makeObjects);
-
-</script>
-</head>
-<body>
-<h1>Pie 2D</h1>
-<!--<p><button onclick="makeObjects();">Go</button></p>-->
-<p>1: Pie with internal labels.</p>
-<div id="test1" style="width: 300px; height: 300px;"></div>
-<p>2: Pie with external labels and precision=0.</p>
-<div id="test2" style="width: 300px; height: 300px;"></div>
-<p>3/4: Two pies with internal and external labels with a constant radius.</p>
-<table border="1"><tr>
-	<td><div id="test3" style="width: 300px; height: 300px;"></div></td>
-	<td><div id="test4" style="width: 300px; height: 300px;"></div></td>
-</tr></table>
-<p>5/6: Pie with internal custom labels and custom colors (#6 is rotated).</p>
-<table border="1"><tr>
-	<td><div id="test5" style="width: 300px; height: 300px;"></div></td>
-	<td><div id="test6" style="width: 300px; height: 300px;"></div></td>
-</tr></table>
-<p>7: Degenerated pie with 1 element.</p>
-<div id="test7" style="width: 200px; height: 200px;"></div>
-<p>8: Degenerated pie with 1 positive elements (out of 5).</p>
-<div id="test8" style="width: 200px; height: 200px;"></div>
-<p>9: Pie with no data.</p>
-<div id="test9" style="width: 200px; height: 200px;"></div>
-<p>10: Pie with all data zero (no data).</p>
-<div id="test10" style="width: 200px; height: 200px;"></div>
-<p>11: Pie with all data zero (no data) and a user-provided message.</p>
-<div id="test11" style="width: 200px; height: 200px;"></div>
-<p>That's all Folks!</p>
-</body>
+				var chart11 = new Chart("test11");
+				chart11.setTheme(Claro);
+				chart11.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "white",
+					radius: 80,
+					zeroDataMessage: "No Non-Zero Data"
+				});
+				chart11.addSeries("Series A", [{
+					y: 0,
+					text: "Red",
+					color: "red"
+				}, {
+					y: 0,
+					text: "Green",
+					color: "green"
+				}, {
+					y: 0,
+					text: "Blue",
+					color: "blue"
+				}, {
+					y: 0,
+					text: "Other",
+					color: "white",
+					fontColor: "black"
+				}]);
+				chart11.render();
+			});
+		</script>
+	</head>
+	<body>
+		<h1>Pie 2D</h1>
+		<!--<p><button onclick="makeObjects();">Go</button></p>-->
+		<p>1: Pie with internal labels.</p>
+		<div id="test1" style="width: 300px; height: 300px;"></div>
+		<p>2: Pie with external labels and precision=0.</p>
+		<div id="test2" style="width: 300px; height: 300px;"></div>
+		<p>3/4: Two pies with internal and external labels with a constant radius.</p>
+		<table border="1">
+			<tr>
+				<td>
+					<div id="test3" style="width: 300px; height: 300px;"></div>
+				</td>
+				<td>
+					<div id="test4" style="width: 300px; height: 300px;"></div>
+				</td>
+			</tr>
+		</table>
+		<p>5/6: Pie with internal custom labels and custom colors (#6 is rotated).</p>
+		<table border="1">
+			<tr>
+				<td>
+					<div id="test5" style="width: 300px; height: 300px;"></div>
+				</td>
+				<td>
+					<div id="test6" style="width: 300px; height: 300px;"></div>
+				</td>
+			</tr>
+		</table>
+		<p>7: Degenerated pie with 1 element.</p>
+		<div id="test7" style="width: 200px; height: 200px;"></div>
+		<p>8: Degenerated pie with 1 positive elements (out of 5).</p>
+		<div id="test8" style="width: 200px; height: 200px;"></div>
+		<p>9: Pie with no data.</p>
+		<div id="test9" style="width: 200px; height: 200px;"></div>
+		<p>10: Pie with all data zero (no data).</p>
+		<div id="test10" style="width: 200px; height: 200px;"></div>
+		<p>11: Pie with all data zero (no data) and a message.</p>
+		<div id="test11" style="width: 200px; height: 200px;"></div>
+		<p>That's all Folks!</p>
+	</body>
 </html>

--- a/charting/tests/test_pie2d_innerRadius.html
+++ b/charting/tests/test_pie2d_innerRadius.html
@@ -1,208 +1,265 @@
-<!--[if IE 7]>
-<!DOCTYPE>
-<html lang="en">
-	<head>
-<![endif]-->
-<!--[if IE 8]>
-<!DOCTYPE>
-<html lang="en">
-    <head>
-           <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7"/>
-<![endif]-->
-<![if gte IE 9]>
 <!DOCTYPE HTML>
-<html lang="en">
+<html>
 	<head>
-<![endif]>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Pie 2D</title>
-<style type="text/css">
-	@import "../../../dojo/resources/dojo.css";
-	@import "../../../dijit/tests/css/dijitTests.css";
-</style>
-<script type="text/javascript" src="../../../dojo/dojo.js" data-dojo-config="isDebug: true"></script>
-<script type="text/javascript">
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<title>Pie 2D</title>
+		<style type="text/css">
+			@import "../../../dojo/resources/dojo.css";
+			@import "../../../dijit/tests/css/dijitTests.css";
+		</style>
+		<script type="text/javascript" src="../../../dojo/dojo.js" data-dojo-config="isDebug: true, async: true"></script>
+		<script type="text/javascript">
+			require([
+				"dojox/charting/Chart",
+				"dojox/charting/plot2d/Pie",
+				"dojox/charting/themes/PlotKit/blue",
+				"dojox/charting/themes/PlotKit/green",
+				"dojox/charting/themes/PlotKit/red",
+				"dojox/charting/themes/Adobebricks",
+				"dojox/charting/themes/Algae",
+				"dojox/charting/themes/Julie",
+				"dojo/domReady!"
+			], function(Chart, Pie, pkBlue, pkGreen, pkRed, Adobebricks, Algae, Julie){
+				var chart1 = new Chart("test1");
+				chart1.setTheme(pkBlue);
+				chart1.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "white",
+					innerRadius: 33,
+					labelOffset: 40
+				});
+				chart1.addSeries("Series A", [4, 2, 1, 1]);
+				chart1.render();
 
-dojo.require("dojox.charting.Chart");
-dojo.require("dojox.charting.plot2d.Pie");
-dojo.require("dojox.charting.themes.PlotKit.blue");
-dojo.require("dojox.charting.themes.PlotKit.green");
-dojo.require("dojox.charting.themes.PlotKit.red");
-dojo.require("dojox.charting.themes.Adobebricks");
-dojo.require("dojox.charting.themes.Algae");
-dojo.require("dojox.charting.themes.Julie");
+				var chart2 = new Chart("test2");
+				chart2.setTheme(pkBlue);
+				chart2.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "black",
+					innerRadius: 33,
+					labelOffset: -25,
+					precision: 0
+				});
+				chart2.addSeries("Series A", [4, 2, 1, 1]);
+				chart2.render();
 
-makeObjects = function(){
-	var chart1 = new dojox.charting.Chart("test1");
-	chart1.setTheme(dojox.charting.themes.PlotKit.blue);
-	chart1.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
-		innerRadius: 33,
-		labelOffset: 40
-	});
-	chart1.addSeries("Series A", [4, 2, 1, 1]);
-	chart1.render();
+				var chart3 = new Chart("test3");
+				chart3.setTheme(pkGreen);
+				chart3.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 10pt Tahoma",
+					fontColor: "white",
+					labelOffset: 25,
+					innerRadius: 33,
+					radius: 90
+				});
+				chart3.addSeries("Series A", [4, 2, 1, 1]);
+				chart3.render();
 
-	var chart2 = new dojox.charting.Chart("test2");
-	chart2.setTheme(dojox.charting.themes.PlotKit.blue);
-	chart2.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "black",
-		innerRadius: 33,
-		labelOffset: -25,
-		precision: 0
-	});
-	chart2.addSeries("Series A", [4, 2, 1, 1]);
-	chart2.render();
+				var chart4 = new Chart("test4");
+				chart4.setTheme(pkGreen);
+				chart4.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 10pt Tahoma",
+					fontColor: "black",
+					labelOffset: -25,
+					innerRadius: 33,
+					radius: 90
+				});
+				chart4.addSeries("Series A", [4, 2, 1, 1]);
+				chart4.render();
 
-	var chart3 = new dojox.charting.Chart("test3");
-	chart3.setTheme(dojox.charting.themes.PlotKit.green);
-	chart3.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 10pt Tahoma",
-		fontColor: "white",
-		labelOffset: 25,
-		innerRadius: 33,
-		radius: 90
-	});
-	chart3.addSeries("Series A", [4, 2, 1, 1]);
-	chart3.render();
+				var chart5 = new Chart("test5");
+				chart5.setTheme(pkRed);
+				chart5.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 14pt Tahoma",
+					fontColor: "white",
+					innerRadius: 33,
+					labelOffset: 40
+				});
+				chart5.addSeries("Series A", [{
+					y: 4,
+					text: "Red"
+				}, {
+					y: 2,
+					text: "Green"
+				}, {
+					y: 1,
+					text: "Blue"
+				}, {
+					y: 1,
+					text: "Other"
+				}]);
+				chart5.render();
 
-	var chart4 = new dojox.charting.Chart("test4");
-	chart4.setTheme(dojox.charting.themes.PlotKit.green);
-	chart4.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 10pt Tahoma",
-		fontColor: "black",
-		labelOffset: -25,
-		innerRadius: 33,
-		radius: 90
-	});
-	chart4.addSeries("Series A", [4, 2, 1, 1]);
-	chart4.render();
+				var chart6 = new Chart("test6");
+				chart6.setTheme(pkRed);
+				chart6.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 14pt Tahoma",
+					fontColor: "white",
+					labelOffset: 40,
+					innerRadius: 33,
+					startAngle: -45
+				});
+				chart6.addSeries("Series A", [{
+					y: 4,
+					text: "Red",
+					color: "red"
+				}, {
+					y: 2,
+					text: "Green",
+					color: "green"
+				}, {
+					y: 1,
+					text: "Blue",
+					color: "blue"
+				}, {
+					y: 1,
+					text: "Other",
+					color: "white",
+					fontColor: "black"
+				}]);
+				chart6.render();
 
-	var chart5 = new dojox.charting.Chart("test5");
-	chart5.setTheme(dojox.charting.themes.PlotKit.red);
-	chart5.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 14pt Tahoma",
-		fontColor: "white",
-		innerRadius: 33,
-		labelOffset: 40
-	});
-	chart5.addSeries("Series A", [{y: 4, text: "Red"}, {y: 2, text: "Green"}, {y: 1, text: "Blue"}, {y: 1, text: "Other"}]);
-	chart5.render();
+				var chart7 = new Chart("test7");
+				chart7.setTheme(Adobebricks);
+				chart7.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "black",
+					innerRadius: 33,
+					radius: 80
+				});
+				chart7.addSeries("Series A", [4]);
+				chart7.render();
 
-	var chart6 = new dojox.charting.Chart("test6");
-	chart6.setTheme(dojox.charting.themes.PlotKit.red);
-	chart6.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 14pt Tahoma",
-		fontColor: "white",
-		labelOffset: 40,
-		innerRadius: 33,
-		startAngle: -45
-	});
-	chart6.addSeries("Series A", [
-		{y: 4, text: "Red", color: "red"},
-		{y: 2, text: "Green", color: "green"},
-		{y: 1, text: "Blue", color: "blue"},
-		{y: 1, text: "Other", color: "white", fontColor: "black"}
-	]);
-	chart6.render();
+				var chart8 = new Chart("test8");
+				chart8.setTheme(Algae);
+				chart8.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "black",
+					innerRadius: 33,
+					radius: 80
+				});
+				chart8.addSeries("Series A", [{
+					y: -1,
+					text: "Red",
+					color: "red"
+				}, {
+					y: 5,
+					text: "Green",
+					color: "green"
+				}, {
+					y: 0,
+					text: "Blue",
+					color: "blue"
+				}, {
+					y: 0,
+					text: "Other",
+					color: "white",
+					fontColor: "black"
+				}]);
+				chart8.render();
 
-	var chart7 = new dojox.charting.Chart("test7");
-	chart7.setTheme(dojox.charting.themes.Adobebricks);
-	chart7.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "black",
-		innerRadius: 33,
-		radius: 80
-	});
-	chart7.addSeries("Series A", [4]);
-	chart7.render();
+				var chart9 = new Chart("test9");
+				chart9.setTheme(Julie);
+				chart9.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					innerRadius: 33,
+					radius: 80
+				});
+				chart9.addSeries("Series A", []);
+				chart9.render();
 
-	var chart8 = new dojox.charting.Chart("test8");
-	chart8.setTheme(dojox.charting.themes.Algae);
-	chart8.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "black",
-		innerRadius: 33,
-		radius: 80
-	});
-	chart8.addSeries("Series A", [
-		{y: -1, text: "Red", color: "red"},
-		{y: 5, text: "Green", color: "green"},
-		{y: 0, text: "Blue", color: "blue"},
-		{y: 0, text: "Other", color: "white", fontColor: "black"}
-	]);
-	chart8.render();
-
-	var chart9 = new dojox.charting.Chart("test9");
-	chart9.setTheme(dojox.charting.themes.Julie);
-	chart9.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		innerRadius: 33,
-		radius: 80
-	});
-	chart9.addSeries("Series A", []);
-	chart9.render();
-
-	var chart11 = new dojox.charting.Chart("test11");
-	chart11.setTheme(dojox.charting.themes.Julie);
-	chart11.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		innerRadius: 33,
-		radius: 80,
-		zeroDataMessage: "No Non-Zero Data"
-	});
-	chart11.addSeries("Series A", [
-		{y: 0, text: "Red", color: "red"},
-		{y: 0, text: "Green", color: "green"},
-		{y: 0, text: "Blue", color: "blue"},
-		{y: 0, text: "Other", color: "white", fontColor: "black"}
-	]);
-	chart11.render();
-};
-
-dojo.addOnLoad(makeObjects);
-
-</script>
-</head>
-<body>
-<h1>Pie 2D</h1>
-<!--<p><button onclick="makeObjects();">Go</button></p>-->
-<p>1: Pie with internal labels.</p>
-<div id="test1" style="width: 300px; height: 300px;"></div>
-<p>2: Pie with external labels and precision=0.</p>
-<div id="test2" style="width: 300px; height: 300px;"></div>
-<p>3/4: Two pies with internal and external labels with a constant radius.</p>
-<table border="1"><tr>
-	<td><div id="test3" style="width: 300px; height: 300px;"></div></td>
-	<td><div id="test4" style="width: 300px; height: 300px;"></div></td>
-</tr></table>
-<p>5/6: Pie with internal custom labels and custom colors (#6 is rotated).</p>
-<table border="1"><tr>
-	<td><div id="test5" style="width: 300px; height: 300px;"></div></td>
-	<td><div id="test6" style="width: 300px; height: 300px;"></div></td>
-</tr></table>
-<p>7: Degenerated pie with 1 element.</p>
-<div id="test7" style="width: 200px; height: 200px;"></div>
-<p>8: Degenerated pie with 1 positive elements (out of 5).</p>
-<div id="test8" style="width: 200px; height: 200px;"></div>
-<p>9: Pie with no data.</p>
-<div id="test9" style="width: 200px; height: 200px;"></div>
-<p>10: Pie with all data zero (no data).</p>
-<div id="test10" style="width: 200px; height: 200px;"></div>
-<p>11: Pie with all data zero (no data) and a message.</p>
-<div id="test11" style="width: 200px; height: 200px;"></div>
-<p>That's all Folks!</p>
-</body>
+				var chart10 = new Chart("test10");
+				chart10.setTheme(Julie);
+				chart10.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					innerRadius: 33,
+					radius: 80,
+					zeroDataMessage: "No Non-Zero Data"
+				});
+				chart10.addSeries("Series A", []);
+				chart10.render();
+				
+				var chart11 = new Chart("test11");
+				chart11.setTheme(Julie);
+				chart11.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					innerRadius: 33,
+					radius: 80,
+					zeroDataMessage: "No Non-Zero Data"
+				});
+				chart11.addSeries("Series A", [{
+					y: 0,
+					text: "Red",
+					color: "red"
+				}, {
+					y: 0,
+					text: "Green",
+					color: "green"
+				}, {
+					y: 0,
+					text: "Blue",
+					color: "blue"
+				}, {
+					y: 0,
+					text: "Other",
+					color: "white",
+					fontColor: "black"
+				}]);
+				chart11.render();
+			});
+		</script>
+	</head>
+	<body>
+		<h1>Pie 2D</h1>
+		<!--<p><button onclick="makeObjects();">Go</button></p>-->
+		<p>1: Pie with internal labels.</p>
+		<div id="test1" style="width: 300px; height: 300px;"></div>
+		<p>2: Pie with external labels and precision=0.</p>
+		<div id="test2" style="width: 300px; height: 300px;"></div>
+		<p>3/4: Two pies with internal and external labels with a constant radius.</p>
+		<table border="1">
+			<tr>
+				<td>
+					<div id="test3" style="width: 300px; height: 300px;"></div>
+				</td>
+				<td>
+					<div id="test4" style="width: 300px; height: 300px;"></div>
+				</td>
+			</tr>
+		</table>
+		<p>5/6: Pie with internal custom labels and custom colors (#6 is rotated).</p>
+		<table border="1">
+			<tr>
+				<td>
+					<div id="test5" style="width: 300px; height: 300px;"></div>
+				</td>
+				<td>
+					<div id="test6" style="width: 300px; height: 300px;"></div>
+				</td>
+			</tr>
+		</table>
+		<p>7: Degenerated pie with 1 element.</p>
+		<div id="test7" style="width: 200px; height: 200px;"></div>
+		<p>8: Degenerated pie with 1 positive elements (out of 5).</p>
+		<div id="test8" style="width: 200px; height: 200px;"></div>
+		<p>9: Pie with no data.</p>
+		<div id="test9" style="width: 200px; height: 200px;"></div>
+		<p>10: Pie with all data zero (no data).</p>
+		<div id="test10" style="width: 200px; height: 200px;"></div>
+		<p>11: Pie with all data zero (no data) and a message.</p>
+		<div id="test11" style="width: 200px; height: 200px;"></div>
+		<p>That's all Folks!</p>
+	</body>
 </html>
+

--- a/charting/tests/test_pie2d_innerRadius.html
+++ b/charting/tests/test_pie2d_innerRadius.html
@@ -30,7 +30,7 @@ dojo.require("dojox.charting.themes.PlotKit.green");
 dojo.require("dojox.charting.themes.PlotKit.red");
 dojo.require("dojox.charting.themes.Adobebricks");
 dojo.require("dojox.charting.themes.Algae");
-dojo.require("dojox.charting.themes.Claro");
+dojo.require("dojox.charting.themes.Julie");
 
 makeObjects = function(){
 	var chart1 = new dojox.charting.Chart("test1");
@@ -39,6 +39,7 @@ makeObjects = function(){
 		type: "Pie",
 		font: "normal normal bold 12pt Tahoma",
 		fontColor: "white",
+		innerRadius: 33,
 		labelOffset: 40
 	});
 	chart1.addSeries("Series A", [4, 2, 1, 1]);
@@ -50,6 +51,7 @@ makeObjects = function(){
 		type: "Pie",
 		font: "normal normal bold 12pt Tahoma",
 		fontColor: "black",
+		innerRadius: 33,
 		labelOffset: -25,
 		precision: 0
 	});
@@ -63,6 +65,7 @@ makeObjects = function(){
 		font: "normal normal bold 10pt Tahoma",
 		fontColor: "white",
 		labelOffset: 25,
+		innerRadius: 33,
 		radius: 90
 	});
 	chart3.addSeries("Series A", [4, 2, 1, 1]);
@@ -75,6 +78,7 @@ makeObjects = function(){
 		font: "normal normal bold 10pt Tahoma",
 		fontColor: "black",
 		labelOffset: -25,
+		innerRadius: 33,
 		radius: 90
 	});
 	chart4.addSeries("Series A", [4, 2, 1, 1]);
@@ -86,6 +90,7 @@ makeObjects = function(){
 		type: "Pie",
 		font: "normal normal bold 14pt Tahoma",
 		fontColor: "white",
+		innerRadius: 33,
 		labelOffset: 40
 	});
 	chart5.addSeries("Series A", [{y: 4, text: "Red"}, {y: 2, text: "Green"}, {y: 1, text: "Blue"}, {y: 1, text: "Other"}]);
@@ -98,6 +103,7 @@ makeObjects = function(){
 		font: "normal normal bold 14pt Tahoma",
 		fontColor: "white",
 		labelOffset: 40,
+		innerRadius: 33,
 		startAngle: -45
 	});
 	chart6.addSeries("Series A", [
@@ -113,7 +119,8 @@ makeObjects = function(){
 	chart7.addPlot("default", {
 		type: "Pie",
 		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
+		fontColor: "black",
+		innerRadius: 33,
 		radius: 80
 	});
 	chart7.addSeries("Series A", [4]);
@@ -124,7 +131,8 @@ makeObjects = function(){
 	chart8.addPlot("default", {
 		type: "Pie",
 		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
+		fontColor: "black",
+		innerRadius: 33,
 		radius: 80
 	});
 	chart8.addSeries("Series A", [
@@ -136,39 +144,22 @@ makeObjects = function(){
 	chart8.render();
 
 	var chart9 = new dojox.charting.Chart("test9");
-	chart9.setTheme(dojox.charting.themes.Claro);
+	chart9.setTheme(dojox.charting.themes.Julie);
 	chart9.addPlot("default", {
 		type: "Pie",
 		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
+		innerRadius: 33,
 		radius: 80
 	});
 	chart9.addSeries("Series A", []);
 	chart9.render();
 
-	var chart10 = new dojox.charting.Chart("test10");
-	chart10.setTheme(dojox.charting.themes.Claro);
-	chart10.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
-		radius: 80
-	});
-	chart10.addSeries("Series A", [
-		{y: 0, text: "Red", color: "red"},
-		{y: 0, text: "Green", color: "green"},
-		{y: 0, text: "Blue", color: "blue"},
-		{y: 0, text: "Other", color: "white", fontColor: "black"}
-	]);
-	chart10.render();
-
-
 	var chart11 = new dojox.charting.Chart("test11");
-	chart11.setTheme(dojox.charting.themes.Claro);
+	chart11.setTheme(dojox.charting.themes.Julie);
 	chart11.addPlot("default", {
 		type: "Pie",
 		font: "normal normal bold 12pt Tahoma",
-		fontColor: "white",
+		innerRadius: 33,
 		radius: 80,
 		zeroDataMessage: "No Non-Zero Data"
 	});
@@ -210,7 +201,7 @@ dojo.addOnLoad(makeObjects);
 <div id="test9" style="width: 200px; height: 200px;"></div>
 <p>10: Pie with all data zero (no data).</p>
 <div id="test10" style="width: 200px; height: 200px;"></div>
-<p>11: Pie with all data zero (no data) and a user-provided message.</p>
+<p>11: Pie with all data zero (no data) and a message.</p>
 <div id="test11" style="width: 200px; height: 200px;"></div>
 <p>That's all Folks!</p>
 </body>

--- a/charting/tests/test_pie2d_minWidth.html
+++ b/charting/tests/test_pie2d_minWidth.html
@@ -1,67 +1,59 @@
-<!--[if IE 7]>
-<!DOCTYPE>
-<html lang="en">
-	<head>
-<![endif]-->
-<!--[if IE 8]>
-<!DOCTYPE>
-<html lang="en">
-    <head>
-           <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7"/>
-<![endif]-->
-<![if gte IE 9]>
 <!DOCTYPE HTML>
 <html lang="en">
 	<head>
-<![endif]>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<title>Pie 2D</title>
-<style type="text/css">
-	@import "../../../dojo/resources/dojo.css";
-	@import "../../../dijit/tests/css/dijitTests.css";
-</style>
-<script type="text/javascript" src="../../../dojo/dojo.js" data-dojo-config="isDebug: true"></script>
-<script type="text/javascript">
-
-dojo.require("dojox.charting.Chart");
-dojo.require("dojox.charting.widget.Legend");
-dojo.require("dojox.charting.plot2d.Pie");
-dojo.require("dojox.charting.themes.PlotKit.blue");
-dojo.require("dojox.charting.themes.PlotKit.green");
-dojo.require("dojox.charting.themes.PlotKit.red");
-dojo.require("dojox.charting.themes.Adobebricks");
-dojo.require("dojox.charting.themes.Algae");
-
-makeObjects = function () {
-	var chart1 = new dojox.charting.Chart("test1");
-	chart1.setTheme(dojox.charting.themes.PlotKit.blue);
-	chart1.addPlot("default", {
-		type: "Pie",
-		font: "normal normal bold 12pt Tahoma",
-		fontColor: "blue",
-		labelOffset: 5,
-		labelStyle: "columns",
-		labelWiring: "ccc",
-		minWidth: 10 // 10 pixes min
-	});
-	chart1.addSeries("Series A", [{y: 0.004, text: 0.004}, {y: 0.002, text:  0.002}, {y: 400000, text: "400,000"}, {y: 0.004, text: 0.004}]);
-	chart1.render();
-
-	var legend = new dojox.charting.widget.Legend({
-		chart: chart1,
-		horizontal: false
-	}, "legend");
-};
-
-dojo.addOnLoad(makeObjects);
-
-</script>
-</head>
-<body>
-<h1>Pie</h1>
-<p>Pie with 2 slices with one MUCH larger than all the others, but minwidth keeps it from not showing the small ones.</p>
-<div id="test1" style="width: 300px; height: 300px;"></div>
-<div id="legend"></div>
-<p>That's all Folks!</p>
-</body>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+		<title>Pie 2D</title>
+		<style type="text/css">
+			@import "../../../dojo/resources/dojo.css";
+			@import "../../../dijit/tests/css/dijitTests.css";
+		</style>
+		<script type="text/javascript" src="../../../dojo/dojo.js" data-dojo-config="isDebug: true, async: true"></script>
+		<script type="text/javascript">
+			require([
+				"dojox/charting/Chart",
+				"dojox/charting/plot2d/Pie",
+				"dojox/charting/themes/PlotKit/blue",
+				"dojox/charting/widget/Legend",
+				"dojo/domReady!"
+			], function (Chart, Pie, pkBlue, Legend) {
+				var chart1 = new Chart("test1");
+				chart1.setTheme(pkBlue);
+				chart1.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "blue",
+					labelOffset: 5,
+					labelStyle: "columns",
+					labelWiring: "ccc",
+					minWidth: 10 // 10 pixes min
+				});
+				chart1.addSeries("Series A", [{
+					y: 0.004,
+					text: 0.004
+				}, {
+					y: 0.002,
+					text: 0.002
+				}, {
+					y: 400000,
+					text: "400,000"
+				}, {
+					y: 0.004,
+					text: 0.004
+				}]);
+				chart1.render();
+				var legend = Legend({
+					chart: chart1,
+					horizontal: false
+				}, "legend");
+			});
+		</script>
+	</head>
+	<body>
+		<h1>Pie</h1>
+		<p>Pie with 2 slices with one MUCH larger than all the others, but minwidth keeps it from not showing the small ones.</p>
+		<div id="test1" style="width: 300px; height: 300px;"></div>
+		<div id="legend"></div>
+		<p>That's all Folks!</p>
+	</body>
 </html>
+

--- a/charting/tests/test_pie2d_minWidth.html
+++ b/charting/tests/test_pie2d_minWidth.html
@@ -32,7 +32,7 @@ dojo.require("dojox.charting.themes.PlotKit.red");
 dojo.require("dojox.charting.themes.Adobebricks");
 dojo.require("dojox.charting.themes.Algae");
 
-makeObjects = function(){
+makeObjects = function () {
 	var chart1 = new dojox.charting.Chart("test1");
 	chart1.setTheme(dojox.charting.themes.PlotKit.blue);
 	chart1.addPlot("default", {
@@ -41,15 +41,16 @@ makeObjects = function(){
 		fontColor: "blue",
 		labelOffset: 5,
 		labelStyle: "columns",
-		labelWiring: "ccc"
+		labelWiring: "ccc",
+		minWidth: 10 // 10 pixes min
 	});
-	chart1.addSeries("Series A", [4, 4]);
+	chart1.addSeries("Series A", [{y: 0.004, text: 0.004}, {y: 0.002, text:  0.002}, {y: 400000, text: "400,000"}, {y: 0.004, text: 0.004}]);
 	chart1.render();
-	
+
 	var legend = new dojox.charting.widget.Legend({
-        	            chart: chart1,
-							horizontal:false
-                	}, "legend");
+		chart: chart1,
+		horizontal: false
+	}, "legend");
 };
 
 dojo.addOnLoad(makeObjects);
@@ -58,7 +59,7 @@ dojo.addOnLoad(makeObjects);
 </head>
 <body>
 <h1>Pie</h1>
-<p>Pie with 2 50% slices</p>
+<p>Pie with 2 slices with one MUCH larger than all the others, but minwidth keeps it from not showing the small ones.</p>
 <div id="test1" style="width: 300px; height: 300px;"></div>
 <div id="legend"></div>
 <p>That's all Folks!</p>

--- a/charting/tests/test_pie_smart_label.html
+++ b/charting/tests/test_pie_smart_label.html
@@ -1,145 +1,132 @@
-<!--[if IE 7]>
-<!DOCTYPE>
-<html lang="en">
-	<head>
-<![endif]-->
-<!--[if IE 8]>
-<!DOCTYPE>
-<html lang="en">
-    <head>
-           <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7"/>
-<![endif]-->
-<![if gte IE 9]>
 <!DOCTYPE HTML>
 <html lang="en">
 	<head>
-<![endif]>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>Pie 2D: Smart Label</title>
-        <style type="text/css">
-        	@import "../../../dojo/resources/dojo.css";
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<title>Pie 2D: Smart Label</title>
+		<style type="text/css">
+			@import "../../../dojo/resources/dojo.css";
 			@import "../../../dijit/tests/css/dijitTests.css";
 			@import "../../../dijit/themes/claro/claro.css";
 			@import "../resources/Legend.css";
-        </style>
-        <script type="text/javascript" src="../../../dojo/dojo.js" data-dojo-config="parseOnLoad:true">
-        </script>
-        <script type="text/javascript">
-            dojo.require("dojox.charting.Chart");
-            dojo.require("dojox.charting.plot2d.Pie");
-            dojo.require("dojox.charting.action2d.Tooltip");
-            dojo.require("dojox.charting.themes.Tom");
-            dojo.require("dojox.charting.widget.Legend");
+		</style>
+		<script type="text/javascript" src="../../../dojo/dojo.js" data-dojo-config="parseOnLoad:true, async: true"></script>
+		<script type="text/javascript">
+			require([
+				"dojox/charting/Chart",
+				"dojox/charting/plot2d/Pie",
+				"dojox/charting/action2d/Tooltip",
+				"dojox/charting/themes/Tom",
+				"dojox/charting/widget/Legend",
+				"dojo/domReady!"
+			], function (Chart, Pie, TooltipAction, Tom, Legend) {
+				var pieChart = null;
+				var legend = null;
+				pieChart = new Chart("pieChart");
+				pieChart.setTheme(Tom).addPlot("default", {
+					type: Pie,
+					font: "normal normal 10pt Tahoma",
+					fontColor: "#ccc",
+					labelWiring: "#ccc",
+					labelStyle: "columns",
+					htmlLabels: true,
+					startAngle: -10
+				}).addSeries("Series A", [{
+					y: 12.1,
+					text: "China",
+					tooltip: "1,210 million"
+				}, {
+					y: 9.52,
+					text: "India",
+					tooltip: "952 million"
+				}, {
+					y: 2.66,
+					text: "USA",
+					tooltip: "266 million"
+				}, {
+					y: 2.06,
+					text: "Indonisia",
+					tooltip: "206 million"
+				}, {
+					y: 1.63,
+					text: "Brazil",
+					tooltip: "163 million"
+				}, {
+					y: 1.48,
+					text: "Russian",
+					tooltip: "148 million"
+				}, {
+					y: 1.29,
+					text: "Pakistan",
+					tooltip: "129 million"
+				}, {
+					y: 1.25,
+					text: "Japan",
+					tooltip: "125 million"
+				}, {
+					y: 1.23,
+					text: "Bangladesh",
+					tooltip: "123 million"
+				}, {
+					y: 1.04,
+					text: "Nigeria",
+					tooltip: "104 million"
+				}, {
+					y: 0.96,
+					text: "Mexico",
+					tooltip: "96 million"
+				}, {
+					y: 0.84,
+					text: "Germany",
+					tooltip: "84 million"
+				}, {
+					y: 0.74,
+					text: "Phillippines",
+					tooltip: "74 million"
+				}, {
+					y: 0.74,
+					text: "Viet Nam",
+					tooltip: "74 million"
+				}, {
+					y: 0.66,
+					text: "Iran",
+					tooltip: "66 million"
+				}, {
+					y: 0.64,
+					text: "Egypt",
+					tooltip: "64 million"
+				}]);
+				var anim_c = new TooltipAction(pieChart, "default");
+				pieChart.render();
+				legend = new Legend({
+					chart: pieChart,
+					horizontal: false
+				}, "legend");
 
-            var pieChart = null;
-            var legend = null;
-            dojo.addOnLoad(function () {
-            	var dc = dojox.charting;
-            	pieChart = new dc.Chart("pieChart");
-            	pieChart.setTheme(dc.themes.Tom).addPlot("default", {
-            		type: "Pie",
-            		font: "normal normal 10pt Tahoma",
-            		fontColor: "#ccc",
-            		labelWiring: "#ccc",
-            		labelStyle: "columns",
-            		htmlLabels: true,
-            		startAngle: -10
-            	}).addSeries("Series A", [{
-            		y: 12.1,
-            		text: "China",
-            		tooltip: "1,210 million"
-            	}, {
-            		y: 9.52,
-            		text: "India",
-            		tooltip: "952 million"
-            	}, {
-            		y: 2.66,
-            		text: "USA",
-            		tooltip: "266 million"
-            	}, {
-            		y: 2.06,
-            		text: "Indonisia",
-            		tooltip: "206 million"
-            	}, {
-            		y: 1.63,
-            		text: "Brazil",
-            		tooltip: "163 million"
-            	}, {
-            		y: 1.48,
-            		text: "Russian",
-            		tooltip: "148 million"
-            	}, {
-            		y: 1.29,
-            		text: "Pakistan",
-            		tooltip: "129 million"
-            	}, {
-            		y: 1.25,
-            		text: "Japan",
-            		tooltip: "125 million"
-            	}, {
-            		y: 1.23,
-            		text: "Bangladesh",
-            		tooltip: "123 million"
-            	}, {
-            		y: 1.04,
-            		text: "Nigeria",
-            		tooltip: "104 million"
-            	}, {
-            		y: 0.96,
-            		text: "Mexico",
-            		tooltip: "96 million"
-            	}, {
-            		y: 0.84,
-            		text: "Germany",
-            		tooltip: "84 million"
-            	}, {
-            		y: 0.74,
-            		text: "Phillippines",
-            		tooltip: "74 million"
-            	}, {
-            		y: 0.74,
-            		text: "Viet Nam",
-            		tooltip: "74 million"
-            	}, {
-            		y: 0.66,
-            		text: "Iran",
-            		tooltip: "66 million"
-            	}, {
-            		y: 0.64,
-            		text: "Egypt",
-            		tooltip: "64 million"
-            	}]);
-            	var anim_c = new dc.action2d.Tooltip(pieChart, "default");
-            	pieChart.render();
-            	legend = new dojox.charting.widget.Legend({
-            		chart: pieChart,
-            		horizontal: false
-            	}, "legend");
-            });
-
-            function refreshChart() {
-            	var newData = [];
-            	for (var i = 0; i < 16; i++) {
-            		newData.push(Math.random() * 10);
-            	}
-            	newData.sort(function (v1, v2) {
-            		return v2 - v1
-            	});
-            	pieChart.updateSeries("Series A", newData);
-            	pieChart.render();
-            	legend.refresh();
-            }
-        </script>
-    </head>
-    <body class="claro">
-    	<h1>Pie 2D: Smart Label</h1>
+				refreshChart = function () {
+					var newData = [];
+					for (var i = 0; i < 16; i++) {
+						newData.push(Math.random() * 10);
+					}
+					newData.sort(function (v1, v2) {
+						return v2 - v1
+					});
+					pieChart.updateSeries("Series A", newData);
+					pieChart.render();
+					legend.refresh();
+				}
+			});
+		</script>
+	</head>
+	<body class="claro">
+		<h1>Pie 2D: Smart Label</h1>
 		<p>Example of Pie chart using smart label:</p>
-        <div style="margin:20px">
-            <div id="pieChart" style="width: 470px; height: 350px; float:left;">
-            </div>
-            <div id="legend">
-            </div>
-        </div>
+		<div style="margin:20px">
+			<div id="pieChart" style="width: 470px; height: 350px; float:left;">
+			</div>
+			<div id="legend">
+			</div>
+		</div>
 		<button onclick="refreshChart()">Random Data Test</button>
-    </body>
+	</body>
 </html>
+

--- a/charting/tests/test_pie_smart_label.html
+++ b/charting/tests/test_pie_smart_label.html
@@ -28,105 +28,107 @@
             dojo.require("dojox.charting.Chart");
             dojo.require("dojox.charting.plot2d.Pie");
             dojo.require("dojox.charting.action2d.Tooltip");
-			dojo.require("dojox.charting.themes.Tom");
+            dojo.require("dojox.charting.themes.Tom");
             dojo.require("dojox.charting.widget.Legend");
-			
+
             var pieChart = null;
-			var legend = null;
-            dojo.addOnLoad(function(){
-                var dc = dojox.charting;
-                pieChart = new dc.Chart("pieChart");
-                pieChart.setTheme(dc.themes.Tom).addPlot("default", {
-                    type: "Pie",
-                    font: "normal normal 10pt Tahoma",
-					fontColor: "#ccc",
-					labelWiring: "#ccc",
-                    radius: 100,
-					labelStyle: "columns",
-					htmlLabels: true,
-					startAngle: -10
-                }).addSeries("Series A", [{
-                    y: 12.1,
-                    text: "China",
-                    tooltip: "1,210 million"
-                },{
-                    y: 9.52,
-                    text: "India",
-                    tooltip: "952 million"
-                }, {
-                    y: 2.66,
-                    text: "USA",
-                    tooltip: "266 million"
-                }, {
-                    y: 2.06,
-                    text: "Indonisia",
-                    tooltip: "206 million"
-                }, {
-                    y: 1.63,
-                    text: "Brazil",
-                    tooltip: "163 million"
-                },{
-                    y: 1.48,
-                    text: "Russian",
-                    tooltip: "148 million"
-                },{
-                    y: 1.29,
-                    text: "Pakistan",
-                    tooltip: "129 million"
-                },{
-                    y: 1.25,
-                    text: "Japan",
-                    tooltip: "125 million"
-                },{
-                    y: 1.23,
-                    text: "Bangladesh",
-                    tooltip: "123 million"
-                },{
-                    y: 1.04,
-                    text: "Nigeria",
-                    tooltip: "104 million"
-                },{
-                    y: 0.96,
-                    text: "Mexico",
-                    tooltip: "96 million"
-                },{
-                    y: 0.84,
-                    text: "Germany",
-                    tooltip: "84 million"
-                },{
-                    y: 0.74,
-                    text: "Phillippines",
-                    tooltip: "74 million"
-                },{
-                    y: 0.74,
-                    text: "Viet Nam",
-                    tooltip: "74 million"
-                },{
-                    y: 0.66,
-                    text: "Iran",
-                    tooltip: "66 million"
-                },{
-                    y: 0.64,
-                    text: "Egypt",
-                    tooltip: "64 million"
-                }]);
-                var anim_c = new dc.action2d.Tooltip(pieChart, "default");
-                pieChart.render();
-                legend = new dojox.charting.widget.Legend({
-                    chart: pieChart,
-					horizontal:false
-                }, "legend");
+            var legend = null;
+            dojo.addOnLoad(function () {
+            	var dc = dojox.charting;
+            	pieChart = new dc.Chart("pieChart");
+            	pieChart.setTheme(dc.themes.Tom).addPlot("default", {
+            		type: "Pie",
+            		font: "normal normal 10pt Tahoma",
+            		fontColor: "#ccc",
+            		labelWiring: "#ccc",
+            		labelStyle: "columns",
+            		htmlLabels: true,
+            		startAngle: -10
+            	}).addSeries("Series A", [{
+            		y: 12.1,
+            		text: "China",
+            		tooltip: "1,210 million"
+            	}, {
+            		y: 9.52,
+            		text: "India",
+            		tooltip: "952 million"
+            	}, {
+            		y: 2.66,
+            		text: "USA",
+            		tooltip: "266 million"
+            	}, {
+            		y: 2.06,
+            		text: "Indonisia",
+            		tooltip: "206 million"
+            	}, {
+            		y: 1.63,
+            		text: "Brazil",
+            		tooltip: "163 million"
+            	}, {
+            		y: 1.48,
+            		text: "Russian",
+            		tooltip: "148 million"
+            	}, {
+            		y: 1.29,
+            		text: "Pakistan",
+            		tooltip: "129 million"
+            	}, {
+            		y: 1.25,
+            		text: "Japan",
+            		tooltip: "125 million"
+            	}, {
+            		y: 1.23,
+            		text: "Bangladesh",
+            		tooltip: "123 million"
+            	}, {
+            		y: 1.04,
+            		text: "Nigeria",
+            		tooltip: "104 million"
+            	}, {
+            		y: 0.96,
+            		text: "Mexico",
+            		tooltip: "96 million"
+            	}, {
+            		y: 0.84,
+            		text: "Germany",
+            		tooltip: "84 million"
+            	}, {
+            		y: 0.74,
+            		text: "Phillippines",
+            		tooltip: "74 million"
+            	}, {
+            		y: 0.74,
+            		text: "Viet Nam",
+            		tooltip: "74 million"
+            	}, {
+            		y: 0.66,
+            		text: "Iran",
+            		tooltip: "66 million"
+            	}, {
+            		y: 0.64,
+            		text: "Egypt",
+            		tooltip: "64 million"
+            	}]);
+            	var anim_c = new dc.action2d.Tooltip(pieChart, "default");
+            	pieChart.render();
+            	legend = new dojox.charting.widget.Legend({
+            		chart: pieChart,
+            		horizontal: false
+            	}, "legend");
             });
-			function refreshChart(){
-				var newData = [];
-				for(var i = 0; i < 16; i++){
-					newData.push(Math.random()*10);
-				}
-				newData.sort(function(v1,v2){return v2 - v1});
-				pieChart.updateSeries("Series A", newData);
-				pieChart.render();
-				legend.refresh();
-			}
+
+            function refreshChart() {
+            	var newData = [];
+            	for (var i = 0; i < 16; i++) {
+            		newData.push(Math.random() * 10);
+            	}
+            	newData.sort(function (v1, v2) {
+            		return v2 - v1
+            	});
+            	pieChart.updateSeries("Series A", newData);
+            	pieChart.render();
+            	legend.refresh();
+            }
         </script>
     </head>
     <body class="claro">


### PR DESCRIPTION


This is related to trac: https://bugs.dojotoolkit.org/ticket/18076
A lot of this work was done by Eugene Lazutkin(uhop) with additional work, tests, and merging performed by myself.

This submission adds the following:

1.) Much improved handling of the smart (column) labels. It will dynamically resize the Pie radius to fit all the labels now. You no longer need to have to trial/error set the radius. Label layout is much improved.

2.) Much improved radius handling in general. It will now try to maximize the usage of the space inside the chart area (max radius) unless otherwise specified. This combined with the label improvements means you rarely need to set radius now to get a good-rendering pie. You still can and it works as it always has, but dynamic is better.

3.) Support for ring-style pie charts. You can now set an innerRadius property on the Pie plot and it will use that to generate a ring style chart. Positive values work as percentage of whole (dynamic sizing). Negative values work as exact pixels (fixed size). This may seem odd, but it avoid having to string process to extract % or the like and is more efficient. In general percentages would be the likely use case as it stands so was made the common positive meaning.

4.) Theme support for setting the pieInnerRadius.

5.) minWidth support. This is so that you can always keep some aspect of a slice visible, particularly if that slice is going to have hover effects, like a tooltip. The default is 0, which means the feature is off and the Pie works as it always has. But, with a positive value, it will now force any slice < that size to scale up to that size so you can always have a minimum dimension. Yes, in theory this does skew pie plots a bit if enabled but it is also useful for many slices or conditions where you want even the smallest slice to show up and be hoverable.
