### PR TITLE
Fix patth repeated duplication error in VML renderer, fixes #16830

### DIFF
--- a/gfx/utils.js
+++ b/gfx/utils.js
@@ -309,6 +309,10 @@ define(["dojo/_base/kernel","dojo/_base/lang","./_base", "dojo/_base/html","dojo
 				svg = svg.replace(/\bdojoGfx\w*\s*=\s*(['"])\w*\1/g, "");
 				svg = svg.replace(/\b__gfxObject__\s*=\s*(['"])\w*\1/g, "");
 				svg = svg.replace(/[=]([^"']+?)(\s|>)/g,'="$1"$2');
+				
+				// Undefined strokes (IE 8 seralization weirdness) should be removed to  
+				// allow default.  'undefined' is not a valid value. 
+				svg = svg.replace(/\bstroke-opacity\w*\s*=\s*(['"])undefined\1/g, ""); 				
 			}
 			return svg;  //Cleaned SVG text.
 		}

--- a/gfx/vml.js
+++ b/gfx/vml.js
@@ -1022,7 +1022,21 @@ function(lang, declare, arr, Color, has, config, dom, domGeom, kernel, g, gs, pa
 		_closePath: function(){
 			this.lastControl.type = "";	// no control point after this primitive
 			return ["x"];
-		}
+		},
+		_getRealBBox: function(){ 
+			//	summary: 
+			//		returns an array of four points or null 
+			//		This is called by setFill, which actually creates the path, so we want to avoid 
+			//		duping the path repeatedly in the shape by clearing the path before re-add. 
+			this._confirmSegmented(); 
+			if(this.tbbox){ 
+				return this.tbbox;	// Array 
+			} 
+			if(typeof this.shape.path == "string"){ 
+				this.shape.path = ""; 
+			} 
+			return this.inherited(arguments); 
+		} 		
 	});
 	vml.Path.nodeType = "shape";
 


### PR DESCRIPTION
This is a set of fixes for some minor IE8/VML bugs that cause problems when serializing out the VML surface into either JSON, or into SVG.  Both fixes have been available for a while, so I am going to commit them into trunk and resolve this bug.
