### PR TITLE
Refactor SHA2 algorithms, add basic tests

### DIFF
--- a/encoding/digests/SHA224.js
+++ b/encoding/digests/SHA224.js
@@ -1,68 +1,9 @@
-define(["./_sha-32"], function(sha32){
+define(["./_sha-32", "./_sha2"], function(sha32, sha2){
 	//	The 224-bit implementation of SHA-2
 	var hash = [
 		0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939,
 		0xffc00b31, 0x68581511, 0x64f98fa7, 0xbefa4fa4
 	];
 
-	var SHA224 = function(/* String */data, /* sha32.outputTypes? */outputType){
-		var out = outputType || sha32.outputTypes.Base64;
-		data = sha32.stringToUtf8(data);
-		var wa = sha32.digest(sha32.toWord(data), data.length * 8, hash, 224);
-		switch(out){
-			case sha32.outputTypes.Raw: {
-				return wa;
-			}
-			case sha32.outputTypes.Hex: {
-				return sha32.toHex(wa);
-			}
-			case sha32.outputTypes.String: {
-				return sha32._toString(wa);
-			}
-			default: {
-				return sha32.toBase64(wa);
-			}
-		}
-	};
-
-	SHA224._hmac = function(/* String */data, /* String */key, /* sha32.outputTypes? */outputType){
-		var out = outputType || sha32.outputTypes.Base64;
-		data = sha32.stringToUtf8(data);
-		key = sha32.stringToUtf8(key);
-
-		//	prepare the key
-		var wa = sha32.toWord(key);
-		if(wa.length > 16){
-			wa = sha32.digest(wa, key.length * 8, hash, 224);
-		}
-
-		//	set up the pads
-		var ipad = new Array(16), opad = new Array(16);
-		for(var i=0; i<16; i++){
-			ipad[i] = wa[i] ^ 0x36363636;
-			opad[i] = wa[i] ^ 0x5c5c5c5c;
-		}
-
-		//	make the final digest
-		var r1 = sha32.digest(ipad.concat(sha32.toWord(data)), 512 + data.length * 8, hash, 224);
-		var r2 = sha32.digest(opad.concat(r1), 512 + 160, hash, 224);
-
-		//	return the output.
-		switch(out){
-			case sha32.outputTypes.Raw: {
-				return wa;
-			}
-			case sha32.outputTypes.Hex: {
-				return sha32.toHex(wa);
-			}
-			case sha32.outputTypes.String: {
-				return sha32._toString(wa);
-			}
-			default: {
-				return sha32.toBase64(wa);
-			}
-		}
-	};
-
-	return SHA224;
+	return sha2(sha32, 224, 512, hash);
 });

--- a/encoding/digests/SHA256.js
+++ b/encoding/digests/SHA256.js
@@ -1,68 +1,9 @@
-define(["./_sha-32"], function(sha32){
+define(["./_sha-32", "./_sha2"], function(sha32, sha2){
 	//	The 256-bit implementation of SHA-2
 	var hash = [
 		0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
 		0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
 	];
 
-	var SHA256 = function(/* String */data, /* sha32.outputTypes? */outputType){
-		var out = outputType || sha32.outputTypes.Base64;
-		data = sha32.stringToUtf8(data);
-		var wa = sha32.digest(sha32.toWord(data), data.length * 8, hash, 256);
-		switch(out){
-			case sha32.outputTypes.Raw: {
-				return wa;
-			}
-			case sha32.outputTypes.Hex: {
-				return sha32.toHex(wa);
-			}
-			case sha32.outputTypes.String: {
-				return sha32._toString(wa);
-			}
-			default: {
-				return sha32.toBase64(wa);
-			}
-		}
-	};
-
-	SHA256._hmac = function(/* String */data, /* String */key, /* sha32.outputTypes? */outputType){
-		var out = outputType || sha32.outputTypes.Base64;
-		data = sha32.stringToUtf8(data);
-		key = sha32.stringToUtf8(key);
-
-		//	prepare the key
-		var wa = sha32.toWord(key);
-		if(wa.length > 16){
-			wa = sha32.digest(wa, key.length * 8, hash, 256);
-		}
-
-		//	set up the pads
-		var ipad = new Array(16), opad = new Array(16);
-		for(var i=0; i<16; i++){
-			ipad[i] = wa[i] ^ 0x36363636;
-			opad[i] = wa[i] ^ 0x5c5c5c5c;
-		}
-
-		//	make the final digest
-		var r1 = sha32.digest(ipad.concat(sha32.toWord(data)), 512 + data.length * 8, hash, 256);
-		var r2 = sha32.digest(opad.concat(r1), 512 + 160, hash, 256);
-
-		//	return the output.
-		switch(out){
-			case sha32.outputTypes.Raw: {
-				return wa;
-			}
-			case sha32.outputTypes.Hex: {
-				return sha32.toHex(wa);
-			}
-			case sha32.outputTypes.String: {
-				return sha32._toString(wa);
-			}
-			default: {
-				return sha32.toBase64(wa);
-			}
-		}
-	};
-
-	return SHA256;
+	return sha2(sha32, 256, 512, hash);
 });

--- a/encoding/digests/SHA384.js
+++ b/encoding/digests/SHA384.js
@@ -1,4 +1,4 @@
-define(["./_sha-64"], function(sha64){
+define(["./_sha-64", "./_sha2"], function(sha64, sha2){
 	//	The 384-bit implementation of SHA-2
 	
 	//	Note that for 64-bit hashes, we're actually doing high-order, low-order, high-order, low-order.
@@ -8,64 +8,5 @@ define(["./_sha-64"], function(sha64){
 		0x67332667, 0xffc00b31, 0x8eb44a87, 0x68581511, 0xdb0c2e0d, 0x64f98fa7, 0x47b5481d, 0xbefa4fa4
 	];
 
-	//	the exported function
-	var SHA384 = function(/* String */data, /* sha64.outputTypes? */outputType){
-		var out = outputType || sha64.outputTypes.Base64;
-		data = sha64.stringToUtf8(data);
-		var wa = sha64.digest(sha64.toWord(data), data.length * 8, hash, 384);
-		switch(out){
-			case sha64.outputTypes.Raw: {
-				return wa;
-			}
-			case sha64.outputTypes.Hex: {
-				return sha64.toHex(wa);
-			}
-			case sha64.outputTypes.String: {
-				return sha64._toString(wa);
-			}
-			default: {
-				return sha64.toBase64(wa);
-			}
-		}
-	};
-	SHA384._hmac = function(/* string */data, /* string */key, /* sha64.outputTypes? */outputType){
-		var out = outputType || sha64.outputTypes.Base64;
-		data = sha64.stringToUtf8(data);
-		key = sha64.stringToUtf8(key);
-
-		//	prepare the key
-		var wa = sha64.toWord(key);
-		if(wa.length > 16){
-			wa = sha64.digest(wa, key.length * 8, hash, 384);
-		}
-
-		//	set up the pads
-		var ipad = new Array(16), opad = new Array(16);
-		for(var i=0; i<16; i++){
-			ipad[i] = wa[i] ^ 0x36363636;
-			opad[i] = wa[i] ^ 0x5c5c5c5c;
-		}
-
-		//	make the final digest
-		var r1 = sha64.digest(ipad.concat(sha64.toWord(data)), 512 + data.length * 8, hash, 384);
-		var r2 = sha64.digest(opad.concat(r1), 512 + 160, hash, 384);
-
-		//	return the output.
-		switch(out){
-			case sha64.outputTypes.Raw: {
-				return wa;
-			}
-			case sha64.outputTypes.Hex: {
-				return sha64.toHex(wa);
-			}
-			case sha64.outputTypes.String: {
-				return sha64._toString(wa);
-			}
-			default: {
-				return sha64.toBase64(wa);
-			}
-		}
-	};
-
-	return SHA384;
+	return sha2(sha64, 384, 1024, hash);
 });

--- a/encoding/digests/SHA512.js
+++ b/encoding/digests/SHA512.js
@@ -1,4 +1,4 @@
-define(["./_sha-64"], function(sha64){
+define(["./_sha-64", "./_sha2"], function(sha64, sha2){
 	//	The 512-bit implementation of SHA-2
 	
 	//	Note that for 64-bit hashes, we're actually doing high-order, low-order, high-order, low-order.
@@ -8,63 +8,5 @@ define(["./_sha-64"], function(sha64){
 		0x510e527f, 0xade682d1, 0x9b05688c, 0x2b3e6c1f, 0x1f83d9ab, 0xfb41bd6b, 0x5be0cd19, 0x137e2179
 	];
 
-	//	the exported function
-	var SHA512 = function(/* String */data, /* sha64.outputTypes? */outputType){
-		var out = outputType || sha64.outputTypes.Base64;
-		data = sha64.stringToUtf8(data);
-		var wa = sha64.digest(sha64.toWord(data), data.length * 8, hash, 512);
-		switch(out){
-			case sha64.outputTypes.Raw: {
-				return wa;
-			}
-			case sha64.outputTypes.Hex: {
-				return sha64.toHex(wa);
-			}
-			case sha64.outputTypes.String: {
-				return sha64._toString(wa);
-			}
-			default: {
-				return sha64.toBase64(wa);
-			}
-		}
-	};
-	SHA512._hmac = function(/* string */data, /* string */key, /* sha64.outputTypes? */outputType){
-		var out = outputType || sha64.outputTypes.Base64;
-		data = sha64.stringToUtf8(data);
-		key = sha64.stringToUtf8(key);
-
-		//	prepare the key
-		var wa = sha64.toWord(key);
-		if(wa.length > 16){
-			wa = sha64.digest(wa, key.length * 8, hash, 512);
-		}
-
-		//	set up the pads
-		var ipad = new Array(16), opad = new Array(16);
-		for(var i=0; i<16; i++){
-			ipad[i] = wa[i] ^ 0x36363636;
-			opad[i] = wa[i] ^ 0x5c5c5c5c;
-		}
-
-		//	make the final digest
-		var r1 = sha64.digest(ipad.concat(sha64.toWord(data)), 512 + data.length * 8, hash, 512);
-		var r2 = sha64.digest(opad.concat(r1), 512 + 160, hash, 512);
-
-		//	return the output.
-		switch(out){
-			case sha64.outputTypes.Raw: {
-				return wa;
-			}
-			case sha64.outputTypes.Hex: {
-				return sha64.toHex(wa);
-			}
-			case sha64.outputTypes.String: {
-				return sha64._toString(wa);
-			}
-			default: {
-				return sha64.toBase64(wa);
-			}
-		}
-	};
-	return SHA512;
+	return sha2(sha64, 512, 1024, hash);
 });

--- a/encoding/digests/_sha2.js
+++ b/encoding/digests/_sha2.js
@@ -1,0 +1,69 @@
+define([], function () {
+	// Return a hashing function for a _sha helper (_sha-32 or _sha-64), a key length, a block size, and a set
+	// of constants.
+	return function (/* sha32/64 */_sha, /* Number */_keyLength, /* Blocksize */_blockSize, /* Array */_hash) {
+		function hasher(/* String */data, /* sha32/64.outputTypes */outputType) {
+			outputType = outputType || _sha.outputTypes.Base64;
+			var wa = _sha.digest(_sha.toWord(data), data.length * 8, _hash, _keyLength);
+
+			switch(outputType){
+				case _sha.outputTypes.Raw: {
+					return wa;
+				}
+				case _sha.outputTypes.Hex: {
+					return _sha.toHex(wa);
+				}
+				case _sha.outputTypes.String: {
+					return _sha._toString(wa);
+				}
+				default: {
+					return _sha.toBase64(wa);
+				}
+			}
+		}
+
+		hasher.hmac = function (/* String */data, /* String */key, /* sha32/64.outputTypes? */outputType) {
+			outputType = outputType || _sha.outputTypes.Base64;
+
+			//	prepare the key
+			var wa = _sha.toWord(key);
+			if(wa.length > 16){
+				wa = _sha.digest(wa, key.length * 8, _hash, _keyLength);
+			}
+
+			//	set up the pads
+			var numWords = _blockSize / 32,
+				ipad = new Array(numWords),
+				opad = new Array(numWords);
+			for(var i=0; i<numWords; i++){
+				ipad[i] = wa[i] ^ 0x36363636;
+				opad[i] = wa[i] ^ 0x5c5c5c5c;
+			}
+
+			//	make the final digest
+			var r1 = _sha.digest(ipad.concat(_sha.toWord(data)), _blockSize + data.length * 8, _hash, _keyLength);
+			var r2 = _sha.digest(opad.concat(r1), _blockSize + _keyLength, _hash, _keyLength);
+
+			//	return the output
+			switch(outputType){
+				case _sha.outputTypes.Raw: {
+					return r2;
+				}
+				case _sha.outputTypes.Hex: {
+					return _sha.toHex(r2);
+				}
+				case _sha.outputTypes.String: {
+					return _sha._toString(r2);
+				}
+				default: {
+					return _sha.toBase64(r2);
+				}
+			}
+		};
+
+		// for backwards compatibility
+		hasher._hmac = hasher.hmac;
+
+		return hasher;
+	};
+});

--- a/encoding/tests/digests/SHA224.js
+++ b/encoding/tests/digests/SHA224.js
@@ -6,6 +6,9 @@ define(['doh', '../../digests/_base', '../../digests/SHA224', "../../digests/_sh
 	];
 	var base64="Iwl9IjQF2CKGQqR3vaJVsyqtvOS9oLP342ydpw==";
 	var hex="23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7";
+	var hmacKey="Jefe";
+	var hmacData="what do ya want for nothing?";
+	var hmacHex="a30e01098bc6dbbf45690f3a7e9e6d0f8bbea2a39e6148008fd05e44";
 
 	doh.register("dojox.encoding.tests.digests.SHA224", [
 		function testBase64Compute(t){
@@ -13,6 +16,9 @@ define(['doh', '../../digests/_base', '../../digests/SHA224', "../../digests/_sh
 		},
 		function testHexCompute(t){
 			t.assertEqual(hex, SHA224(message, ded.outputTypes.Hex));
+		},
+		function testHmacCompute(t){
+			t.assertEqual(hmacHex, SHA224.hmac(hmacData, hmacKey, ded.outputTypes.Hex));
 		}
 	]);
 });

--- a/encoding/tests/digests/SHA256.js
+++ b/encoding/tests/digests/SHA256.js
@@ -2,6 +2,9 @@ define(['doh', '../../digests/_base', '../../digests/SHA256'], function(doh, ded
 	var message="abc";
 	var hex="ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
 	var base64="ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=";
+	var hmacKey="Jefe";
+	var hmacData="what do ya want for nothing?";
+	var hmacHex="5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843";
 
 	doh.register("dojox.encoding.tests.digests.SHA256", [
 		function testBase64Compute(t){
@@ -9,6 +12,9 @@ define(['doh', '../../digests/_base', '../../digests/SHA256'], function(doh, ded
 		},
 		function testHexCompute(t){
 			t.assertEqual(hex, SHA256(message, ded.outputTypes.Hex));
+		},
+		function testHmacCompute(t){
+			t.assertEqual(hmacHex, SHA256.hmac(hmacData, hmacKey, ded.outputTypes.Hex));
 		}
 	]);
 });

--- a/encoding/tests/digests/SHA384.js
+++ b/encoding/tests/digests/SHA384.js
@@ -10,6 +10,9 @@ define(['doh', '../../digests/_base', '../../digests/SHA384', "../../digests/_sh
 
 	var base64="ywB1P0WjXou1oD1pmsZQBycsMqsO3tFjGotgWkP/W+2AhgcroefMI1i67KE0yCWn";
 	var hex="cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7";
+	var hmacKey="Jefe";
+	var hmacData="what do ya want for nothing?";
+	var hmacHex="af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e8e2240ca5e69e2c78b3239ecfab21649";
 
 	console.log("Vector:", vector.map(function(item){
 		return ((item >> 16) & 0xffff).toString(16) + (item & 0xffff).toString(16);
@@ -31,6 +34,9 @@ define(['doh', '../../digests/_base', '../../digests/SHA384', "../../digests/_sh
 		},
 		function testHexCompute(t){
 			t.assertEqual(hex, SHA384(message, ded.outputTypes.Hex));
+		},
+		function testHmacCompute(t){
+			t.assertEqual(hmacHex, SHA384.hmac(hmacData, hmacKey, ded.outputTypes.Hex));
 		}
 	]);
 });

--- a/encoding/tests/digests/SHA512.js
+++ b/encoding/tests/digests/SHA512.js
@@ -10,6 +10,9 @@ define(['doh', '../../digests/_base', '../../digests/SHA512'],
 
 	var base64="3a81oZNherrMQXNJriBBMRLm+k6JqX6iCp7u5ktV05ohkpkqJ0/BqDa6PCOj/uu9RU1EI2Q86A4qmslPpUyknw==";
 	var hex="ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f";
+	var hmacKey="Jefe";
+	var hmacData="what do ya want for nothing?";
+	var hmacHex="164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737";
 
 	doh.register("dojox.encoding.tests.digests.SHA512", [
 		function testBase64Compute(t){
@@ -17,6 +20,9 @@ define(['doh', '../../digests/_base', '../../digests/SHA512'],
 		},
 		function testHexCompute(t){
 			t.assertEqual(hex, SHA512(message, ded.outputTypes.Hex));
+		},
+		function testHmacCompute(t){
+			t.assertEqual(hmacHex, SHA512.hmac(hmacData, hmacKey, ded.outputTypes.Hex));
 		}
 	]);
 });


### PR DESCRIPTION
The algorithms now share most of their implementation code, and more importantly, they generate correct output.

Test data is taken from RFC 4321: "Identifiers and Test Vectors for HMAC-SHA-224, HMAC-SHA-256, HMAC-SHA-384, and HMAC-SHA-512"

Fixes #18221, #17733
