### PR TITLE
#18302 - dojox/widget/toaster - Do not override existing element ID on IE

### DIFF
--- a/widget/Toaster.js
+++ b/widget/Toaster.js
@@ -17,7 +17,7 @@ define([
 ], function(declare, lang, connect, baseFx, domStyle, domClass, domGeometry, registry, WidgetBase, Templated, BackgroundIframe, coreFx, has, baseWindow, window){
 
 	lang.getObject("dojox.widget", true);
-	
+
 	var capitalize = function(/* String */w){
 	    return w.substring(0,1).toUpperCase() + w.substring(1);
 	};
@@ -251,7 +251,9 @@ define([
 			style.clip = "rect(0px, " + nodeSize.w + "px, " + nodeSize.h + "px, 0px)";
 			if(has("ie")){
 				if(!this.bgIframe){
-					this.clipNode.id || (this.clipNode.id = registry.getUniqueId("dojox_widget_Toaster_clipNode"));
+					if (!this.clipNode.id) {
+						this.clipNode.id = registry.getUniqueId("dojox_widget_Toaster_clipNode");
+					}
 					this.bgIframe = new BackgroundIframe(this.clipNode);
 				}
 				var iframe = this.bgIframe.iframe;


### PR DESCRIPTION
On IE, when creating a new Toaster from an element which already has an ID the ID is replaced by a random, unique one. 

This is undesirable since there's no way to further modify the toaster element via CSS by ID.

See [ticket](https://bugs.dojotoolkit.org/ticket/18302)
