### PR TITLE
fix display jumping in iOS8

### DIFF
--- a/mobile/ComboBox.js
+++ b/mobile/ComboBox.js
@@ -151,7 +151,7 @@ define([
 				domAttr.set(this.domNode, "aria-owns", dropDown.id);
 			}
 
-			if(has("touch") && (has('anrdoid') || has("ios") < 8)){
+			if(has("touch") && (!has("ios") || has("ios") < 8)){
 				win.global.scrollBy(0, domGeometry.position(aroundNode, false).y); // don't call scrollIntoView since it messes up ScrollableView
 			}
 


### PR DESCRIPTION
Using a dojox/mobile/ComboBox in iOS8 causes unnecessary scrolling when
the dropdown is opened, which does not occur in previous versions of the
OS. Add a feature test for iOS8. Refs [18317](https://bugs.dojotoolkit.org/ticket/18317).
