### PR TITLE
return promise from dojox/layout/ContentPane

### DIFF
--- a/layout/ContentPane.js
+++ b/layout/ContentPane.js
@@ -87,7 +87,7 @@ return declare("dojox.layout.ContentPane", ContentPane, {
 			scriptHookReplacement: "dijit.byId('"+this.id+"')"
 		};
 
-		this.inherited("_setContent", arguments);
+		return this.inherited("_setContent", arguments);
 	},
 	// could put back _renderStyles by wrapping/aliasing dojox.html._ContentSetter.prototype._renderStyles
 


### PR DESCRIPTION
dijit/layout/ContentPane started returning a promise in
1.8, but that update does not appear to have carried over into this
extension. Fixes [#18344](https://bugs.dojotoolkit.org/ticket/18344)
