### PR TITLE
Update baseURI checking/pull and fallback, fixes #17661

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -54,11 +54,6 @@ Socket.WebSocket = function(args, fallback){
 	// summary:
 	//		A wrapper for WebSocket, than handles standard args and relative URLs
 	var baseURI = document.baseURI || window.location.href;
-	if(!baseURI){
-		// Try some other fallbacks in case baseURI was not defined by the above.  If all else fails, 
-		// just use a dummy/give up, there is problem.
-		baseURI = (document.URL || ((document.location) ? document.location.href : "http://"));
-	}
 	var ws = new WebSocket(new dBaseUrl(baseURI.replace(/^http/i,'ws'), args.url));
 	ws.on = function(type, listener){
 		ws.addEventListener(type, listener, true);

--- a/socket.js
+++ b/socket.js
@@ -38,11 +38,10 @@ var Socket = function(/*dojo.__XhrArgs*/ argsOrUrl){
 	//		|    ...
 	//		| });
 	//		You can also use the Reconnect module:
-	//		| dojo.require("dojox.socket");
-	//		| dojo.require("dojox.socket.Reconnect");
-	//		| var socket = dojox.socket({url:"/comet"});
-	//		| // add auto-reconnect support
-	//		| socket = dojox.socket.Reconnect(socket);
+	//		| require["dojox/socket", "dojox/socket/Reconnect"], function(dxSocket, reconnect){
+	//		|    var socket = dxSocket({url:"/comet"});
+	//		|    // add auto-reconnect support
+	//		|    socket = reconnect(socket);
 	if(typeof argsOrUrl == "string"){
 		argsOrUrl = {url: argsOrUrl};
 	}

--- a/socket.js
+++ b/socket.js
@@ -25,18 +25,17 @@ var Socket = function(/*dojo.__XhrArgs*/ argsOrUrl){
 	// returns:
 	//		An object that implements the WebSocket API
 	// example:
-	//		| dojo.require("dojox.socket");
-	//		| var socket = dojox.socket({"url://comet-server/comet");
-	//		| // we could also add auto-reconnect support
-	//		| // now we can connect to standard HTML5 WebSocket-style events
-	//		| dojo.connect(socket, "onmessage", function(event){
-	//		|    var message = event.data;
-	//		|    // do something with the message
-	//		| });
-	//		| // send something
-	//		| socket.send("hi there");
-	//		| whenDone(function(){
-	//		|   socket.close();
+	//		| require(["dojox/socket", "dojo/aspect"], function(socket, aspect) {
+	//		|    var sock = socket({"url://comet-server/comet");
+	//		|    // we could also add auto-reconnect support
+	//		|    // now we can connect to standard HTML5 WebSocket-style events
+	//		|    aspect.after(socket, "onmessage", function(event){
+	//		|       var message = event.data;
+	//		|       // do something with the message
+	//		|    });
+	//		|    // send something
+	//		|    sock.send("hi there");
+	//		|    ...
 	//		| });
 	//		You can also use the Reconnect module:
 	//		| dojo.require("dojox.socket");

--- a/socket.js
+++ b/socket.js
@@ -1,8 +1,16 @@
-define("dojox/socket", ["dojo", "dojo/on", "dojo/Evented", "dojo/cookie", "dojo/_base/url"], function(dojo, on, Evented) {
+define([
+	"dojo/_base/array",
+	"dojo/_base/lang",
+	"dojo/_base/xhr",
+	"dojo/aspect",
+	"dojo/on",
+	"dojo/Evented",
+	"dojo/_base/url"
+], function(array, lang, xhr, aspect, on, Evented, dBaseUrl) {
 
 var WebSocket = window.WebSocket;
 
-function Socket(/*dojo.__XhrArgs*/ argsOrUrl){
+var Socket = function(/*dojo.__XhrArgs*/ argsOrUrl){
 	// summary:
 	//		Provides a simple socket connection using WebSocket, or alternate
 	//		communication mechanisms in legacy browsers for comet-style communication. This is based
@@ -39,46 +47,54 @@ function Socket(/*dojo.__XhrArgs*/ argsOrUrl){
 	if(typeof argsOrUrl == "string"){
 		argsOrUrl = {url: argsOrUrl};
 	}
-	return WebSocket ? dojox.socket.WebSocket(argsOrUrl, true) : dojox.socket.LongPoll(argsOrUrl);
+	return WebSocket ? Socket.WebSocket(argsOrUrl, true) : Socket.LongPoll(argsOrUrl);
 };
-dojox.socket = Socket;
 
 Socket.WebSocket = function(args, fallback){
 	// summary:
 	//		A wrapper for WebSocket, than handles standard args and relative URLs
-	var ws = new WebSocket(new dojo._Url(document.baseURI.replace(/^http/i,'ws'), args.url));
+	var baseURI = document.baseURI || window.location.href;
+	if(!baseURI){
+		// Try some other fallbacks in case baseURI was not defined by the above.  If all else fails, 
+		// just use a dummy/give up, there is problem.
+		baseURI = (document.URL || ((document.location) ? document.location.href : "http://"));
+	}
+	var ws = new WebSocket(new dBaseUrl(baseURI.replace(/^http/i,'ws'), args.url));
 	ws.on = function(type, listener){
 		ws.addEventListener(type, listener, true);
 	};
 	var opened;
-	dojo.connect(ws, "onopen", function(event){
+	aspect.after(ws, "onopen", function(event){
 		opened = true;
-	});
-	dojo.connect(ws, "onclose", function(event){
+	}, true);
+	aspect.after(ws, "onclose", function(event){
 		if(opened){
 			return;
 		}
 		if(fallback){
-			Socket.replace(ws, dojox.socket.LongPoll(args), true);
+			Socket.replace(ws, Socket.LongPoll(args), true);
 		}
-	});
+	}, true);
 	return ws;
 };
+
 Socket.replace = function(socket, newSocket, listenForOpen){
 	// make the original socket a proxy for the new socket
-	socket.send = dojo.hitch(newSocket, "send");
-	socket.close = dojo.hitch(newSocket, "close");
+	socket.send = lang.hitch(newSocket, "send");
+	socket.close = lang.hitch(newSocket, "close");
+	var proxyEvent = function(type){
+		(newSocket.addEventListener || newSocket.on).call(newSocket, type, function(event){
+			on.emit(socket, event.type, event);
+		}, true);
+	};
+
 	if(listenForOpen){
 		proxyEvent("open");
 	}
 	// redirect the events as well
-	dojo.forEach(["message", "close", "error"], proxyEvent);
-	function proxyEvent(type){
-		(newSocket.addEventListener || newSocket.on).call(newSocket, type, function(event){
-			on.emit(socket, event.type, event);
-		}, true);
-	}
+	array.forEach(["message", "close", "error"], proxyEvent);
 };
+
 Socket.LongPoll = function(/*dojo.__XhrArgs*/ args){
 	// summary:
 	//		Provides a simple long-poll based comet-style socket/connection to a server and returns an
@@ -104,17 +120,18 @@ Socket.LongPoll = function(/*dojo.__XhrArgs*/ args){
 	//		| dojox.socket.LongPoll.add();
 	//		| var socket = dojox.socket({url:"/comet"});
 
-var cancelled = false,
+	var cancelled = false,
 		first = true,
 		timeoutId,
 		connections = [];
 
 	// create the socket object
+	var fire, connect;
 	var socket = {
 		send: function(data){
 			// summary:
 			//		Send some data using XHR or provided transport
-			var sendArgs = dojo.delegate(args);
+			var sendArgs = lang.delegate(args);
 			sendArgs.rawBody = data;
 			clearTimeout(timeoutId);
 			var deferred = first ? (first = false) || socket.firstRequest(sendArgs) :
@@ -124,7 +141,7 @@ var cancelled = false,
 				// got a response
 				socket.readyState = 1;
 				// remove the current connection
-				connections.splice(dojo.indexOf(connections, deferred), 1);
+				connections.splice(array.indexOf(connections, deferred), 1);
 				// reconnect to listen for the next message if there are no active connections,
 				// we queue it up in case one of the onmessage handlers has a message to send
 				if(!connections.length){
@@ -135,7 +152,7 @@ var cancelled = false,
 					fire("message", {data: response}, deferred);
 				}
 			}, function(error){
-				connections.splice(dojo.indexOf(connections, deferred), 1);
+				connections.splice(array.indexOf(connections, deferred), 1);
 				// an error occurred, fire the appropriate event listeners
 				if(!cancelled){
 					fire("error", {error:error}, deferred);
@@ -152,13 +169,14 @@ var cancelled = false,
 			//		Close the connection
 			socket.readyState = 2;
 			cancelled = true;
-			for(var i = 0; i < connections.length; i++){
+			var i;
+			for(i = 0; i < connections.length; i++){
 				connections[i].cancel();
 			}
 			socket.readyState = 3;
 			fire("close", {wasClean:true});
 		},
-		transport: args.transport || dojo.xhrPost,
+		transport: args.transport || xhr.post,
 		args: args,
 		url: args.url,
 		readyState: 0,
@@ -186,7 +204,14 @@ var cancelled = false,
 			}
 		}
 	};
-	function connect(){
+	fire = function(type, object, deferred){
+		if(socket["on" + type]){
+			object.ioArgs = deferred && deferred.ioArgs;
+			object.type = type;
+			on.emit(socket, type, object);
+		}
+	};
+	connect = function(){
 		if(socket.readyState == 0){
 			// we fire the open event now because we really don't know when the "socket"
 			// is truly open, and this gives us a to do a send() and get it included in the
@@ -197,19 +222,14 @@ var cancelled = false,
 		if(!connections.length){
 			socket.send();
 		}
-	}
-	function fire(type, object, deferred){
-		if(socket["on" + type]){
-			object.ioArgs = deferred && deferred.ioArgs;
-			object.type = type;
-			on.emit(socket, type, object);
-		}
-	}
+	};
 	// provide an alias for Dojo's connect method
 	socket.connect = socket.on;
 	// do the initial connection
 	setTimeout(connect);
 	return socket;
 };
+
 return Socket;
+
 });

--- a/socket/Reconnect.js
+++ b/socket/Reconnect.js
@@ -1,54 +1,59 @@
-dojo.provide("dojox.socket.Reconnect");
+define([
+	"dojox/socket", 
+	"dojo/aspect"
+], function(dxSocket, aspect) {
 
-dojox.socket.Reconnect = function(socket, options){
-	// summary:
-	//		Provides auto-reconnection to a websocket after it has been closed
-	// socket:
-	//		Socket to add reconnection support to.
-	// returns:
-	//		An object that implements the WebSocket API
-	// example:
-	//		You can use the Reconnect module:
-	//		| dojo.require("dojox.socket");
-	//		| dojo.require("dojox.socket.Reconnect");
-	//		| var socket = dojox.socket({url:"/comet"});
-	//		| // add auto-reconnect support
-	//		| socket = dojox.socket.Reconnect(socket);
-	options = options || {};
-	var reconnectTime = options.reconnectTime || 10000;
-	
-	var connectHandle = dojo.connect(socket, "onclose", function(event){
-		clearTimeout(checkForOpen);
-		if(!event.wasClean){
-			socket.disconnected(function(){
-				dojox.socket.replace(socket, newSocket = socket.reconnect());
-			});
+	dxSocket.Reconnect = function(socket, options){
+		// summary:
+		//		Provides auto-reconnection to a websocket after it has been closed
+		// socket:
+		//		Socket to add reconnection support to.
+		// returns:
+		//		An object that implements the WebSocket API
+		// example:
+		//		You can use the Reconnect module:
+		//		| require["dojox/socket", "dojox/socket/Reconnect"], function(dxSocket, reconnect){
+		//		|    var socket = dxSocket({url:"/comet"});
+		//		|    // add auto-reconnect support
+		//		|    socket = reconnect(socket);
+		var reconnectTime = options.reconnectTime || 10000;
+		var checkForOpen, newSocket;
+		options = options || {};
+		
+		aspect.after(socket, "onclose", function(event){
+			clearTimeout(checkForOpen);
+			if(!event.wasClean){
+				socket.disconnected(function(){
+					dxSocket.replace(socket, newSocket = socket.reconnect());
+				});
+			}
+		}, true);
+		if(!socket.disconnected){
+			// add a default impl if it doesn't exist
+			socket.disconnected = function(reconnect){
+				setTimeout(function(){
+					reconnect();
+					checkForOpen = setTimeout(function(){
+						//reset the backoff
+						if(newSocket.readyState < 2){
+							reconnectTime = options.reconnectTime || 10000;
+						}
+					}, 10000);
+				}, reconnectTime);
+				// backoff each time
+				reconnectTime *= options.backoffRate || 2;
+			};
 		}
-	});
-	var checkForOpen, newSocket;
-	if(!socket.disconnected){
-		// add a default impl if it doesn't exist
-		socket.disconnected = function(reconnect){
-			setTimeout(function(){
-				reconnect();
-				checkForOpen = setTimeout(function(){
-					//reset the backoff
-					if(newSocket.readyState < 2){
-						reconnectTime = options.reconnectTime || 10000;
-					}
-				}, 10000);
-			}, reconnectTime);
-			// backoff each time
-			reconnectTime *= options.backoffRate || 2;
-		};
-	}
-	if(!socket.reconnect){
-		// add a default impl if it doesn't exist
-		socket.reconnect = function(){
-			return socket.args ?
-				dojox.socket.LongPoll(socket.args) :
-				dojox.socket.WebSocket({url: socket.URL || socket.url}); // different cases for different impls
-		};
-	}
-	return socket;
-};
+		if(!socket.reconnect){
+			// add a default impl if it doesn't exist
+			socket.reconnect = function(){
+				return socket.args ?
+					dxSocket.LongPoll(socket.args) :
+					dxSocket.WebSocket({url: socket.URL || socket.url}); // different cases for different impls
+			};
+		}
+		return socket;
+	};
+	
+	return dxSocket.Reconnect;
+});


### PR DESCRIPTION
This commit fixes an issue in IE10 and IE11 (which do support WebSockets). The .baseURI is not valid in those browsers, so you have to have a more robust fallback and check. The fix below was authored and tested against an actual websocket supporting server and has been verified to work. I also spent some time and did AMD cleanup on the module, getting rid of dojox. dojo. and most deprecated API usage. It now no longer forcibly expects a dojox. namespace and such.