### PR TITLE
set outline-color to -webkit-tap-highlight-color

### DIFF
--- a/mobile/themes/android/Button.css
+++ b/mobile/themes/android/Button.css
@@ -10,6 +10,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-color: #9cacc0;
   border-radius: 3px;
   color: black;

--- a/mobile/themes/android/Carousel.css
+++ b/mobile/themes/android/Carousel.css
@@ -27,7 +27,6 @@
   margin: 0px 2px;
   border-width: 1px;
   /* workaround for android problem */
-
 }
 .mblCarouselTitle {
   margin: 2px 0px 2px 4px;
@@ -49,6 +48,7 @@
 .mblCarouselItem {
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblCarouselItemHeaderText {
   color: white;

--- a/mobile/themes/android/CheckBox.css
+++ b/mobile/themes/android/CheckBox.css
@@ -12,6 +12,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #9cacc0;

--- a/mobile/themes/android/IconContainer-compat.css
+++ b/mobile/themes/android/IconContainer-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons-compat.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross-compat.css");
 /* dojox.mobile.IconContainer */
 .mblIconItemPaneHeading {

--- a/mobile/themes/android/IconContainer.css
+++ b/mobile/themes/android/IconContainer.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross.css");
 /* dojox.mobile.IconContainer */
 .mblIconContainer {
@@ -11,10 +10,10 @@
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   list-style-type: none;
   float: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblIconItemTerminator {
   list-style-type: none;

--- a/mobile/themes/android/IconMenu.css
+++ b/mobile/themes/android/IconMenu.css
@@ -5,6 +5,7 @@
   border-radius: 6px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   padding: 0;
   background-color: rgba(64, 64, 64, 0.85);
   border: 2px solid #eeeeee;

--- a/mobile/themes/android/ListItem-compat.css
+++ b/mobile/themes/android/ListItem-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow-compat.css");
-
 @import url("../common/domButtons/DomButtonWhiteCheck-compat.css");
 /* dojox.mobile.ListItem */
 .mblListItemSelected {

--- a/mobile/themes/android/ListItem.css
+++ b/mobile/themes/android/ListItem.css
@@ -1,17 +1,16 @@
 @import url("../common/domButtons/DomButtonGrayArrow.css");
-
 @import url("../common/domButtons/DomButtonWhiteCheck.css");
 /* dojox.mobile.ListItem */
 .mblListItem {
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   padding: 0 8px;
   height: 64px;
   list-style-type: none;
   line-height: 64px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-bottom: 1px solid #313431;
   background-color: black;
   font-size: 21px;

--- a/mobile/themes/android/ListItem_rtl.css
+++ b/mobile/themes/android/ListItem_rtl.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow_rtl.css");
-
 @import url("../common/domButtons/DomButtonWhiteCheck_rtl.css");
 /* dojox.mobile.ListItem Rtl*/
 .mblListItemRtl .mblListItemDeleteIcon {

--- a/mobile/themes/android/Overlay.css
+++ b/mobile/themes/android/Overlay.css
@@ -1,5 +1,4 @@
 @import url("../common/transitions/coverv.css");
-
 @import url("../common/transitions/revealv.css");
 /* dojox.mobile.Overlay */
 .mblOverlay {

--- a/mobile/themes/android/PageIndicator.css
+++ b/mobile/themes/android/PageIndicator.css
@@ -4,6 +4,7 @@
   width: 100%;
   height: 20px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblPageIndicatorContainer {
   margin-top: 4px;

--- a/mobile/themes/android/RadioButton.css
+++ b/mobile/themes/android/RadioButton.css
@@ -13,6 +13,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #9cacc0;

--- a/mobile/themes/android/Slider.css
+++ b/mobile/themes/android/Slider.css
@@ -62,4 +62,5 @@
   height: 100%;
   background-color: transparent;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }

--- a/mobile/themes/android/SpinWheel.css
+++ b/mobile/themes/android/SpinWheel.css
@@ -36,6 +36,7 @@
   border-left: solid 2px #000000;
   border-right: solid 2px #000000;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSpinWheelSlotLabel {
   padding: 0 8px;

--- a/mobile/themes/android/Switch.css
+++ b/mobile/themes/android/Switch.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   text-align: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblListItem .mblSwitch {
   position: absolute;

--- a/mobile/themes/android/TabBar.css
+++ b/mobile/themes/android/TabBar.css
@@ -24,6 +24,7 @@
   overflow: hidden;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   position: relative;
   list-style-type: none;
   float: left;
@@ -138,7 +139,6 @@
   color: #000000;
   background-color: #c6c6c6;
   /* TODO: to compat */
-
   background-image: -webkit-gradient(linear, left top, left bottom, from(#dfdfdf), to(#a6a6a6));
   background-image: linear-gradient(to bottom, #dfdfdf 0%, #a6a6a6 100%);
 }
@@ -151,7 +151,6 @@
   color: #ffffff;
   background-color: #3578b1;
   /* TODO: to compat */
-
   background-image: -webkit-gradient(linear, left top, left bottom, from(#313031), to(#959595), color-stop(0.5, #5a555a), color-stop(0.5, #616161));
   background-image: linear-gradient(to bottom, #313031 0%, #5a555a 50%, #616161 50%, #959595 100%);
 }

--- a/mobile/themes/android/ToggleButton.css
+++ b/mobile/themes/android/ToggleButton.css
@@ -11,6 +11,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-color: #9cacc0;
   border-radius: 3px;
   font-size: 13px;

--- a/mobile/themes/android/ToolBarButton.css
+++ b/mobile/themes/android/ToolBarButton.css
@@ -4,6 +4,7 @@
   position: relative;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   margin: 6px;
   padding: 0 10px;
   height: 29px;

--- a/mobile/themes/android/ValuePicker.css
+++ b/mobile/themes/android/ValuePicker.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayPlus.css");
-
 @import url("../common/domButtons/DomButtonGrayMinus.css");
 /* dojox.mobile.ValuePicker */
 .mblValuePicker {

--- a/mobile/themes/android/View.css
+++ b/mobile/themes/android/View.css
@@ -1,7 +1,5 @@
 @import url("../common/transitions/slide.css");
-
 @import url("../common/transitions/flip.css");
-
 @import url("../common/transitions/fade.css");
 /* dojox.mobile.View */
 .mblView {

--- a/mobile/themes/blackberry/Button.css
+++ b/mobile/themes/blackberry/Button.css
@@ -10,6 +10,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-color: #9cacc0;
   border-radius: 6px;
   color: black;

--- a/mobile/themes/blackberry/Carousel.css
+++ b/mobile/themes/blackberry/Carousel.css
@@ -27,7 +27,6 @@
   margin: 0px 2px;
   border-width: 1px;
   /* workaround for android problem */
-
 }
 .mblCarouselTitle {
   margin: 2px 0px 2px 4px;
@@ -49,6 +48,7 @@
 .mblCarouselItem {
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblCarouselItemHeaderText {
   color: white;

--- a/mobile/themes/blackberry/CheckBox.css
+++ b/mobile/themes/blackberry/CheckBox.css
@@ -12,6 +12,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #9cacc0;

--- a/mobile/themes/blackberry/IconContainer-compat.css
+++ b/mobile/themes/blackberry/IconContainer-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons-compat.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross-compat.css");
 /* dojox.mobile.IconContainer */
 .mblIconItemPaneHeading {

--- a/mobile/themes/blackberry/IconContainer.css
+++ b/mobile/themes/blackberry/IconContainer.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross.css");
 /* dojox.mobile.IconContainer */
 .mblIconContainer {
@@ -11,10 +10,10 @@
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   list-style-type: none;
   float: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblIconItemTerminator {
   list-style-type: none;

--- a/mobile/themes/blackberry/IconMenu.css
+++ b/mobile/themes/blackberry/IconMenu.css
@@ -5,6 +5,7 @@
   border-radius: 6px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   padding: 8px;
   background-color: #000000;
   border: none;

--- a/mobile/themes/blackberry/ListItem-compat.css
+++ b/mobile/themes/blackberry/ListItem-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow-compat.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck-compat.css");
 /* dojox.mobile.ListItem */
 .mblListItemSelected {

--- a/mobile/themes/blackberry/ListItem.css
+++ b/mobile/themes/blackberry/ListItem.css
@@ -1,17 +1,16 @@
 @import url("../common/domButtons/DomButtonGrayArrow.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck.css");
 /* dojox.mobile.ListItem */
 .mblListItem {
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   padding: 0 8px;
   height: 59px;
   list-style-type: none;
   line-height: 59px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-bottom: 1px solid #dedfde;
   font-size: 18px;
   color: black;

--- a/mobile/themes/blackberry/ListItem_rtl.css
+++ b/mobile/themes/blackberry/ListItem_rtl.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow_rtl.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck_rtl.css");
 /* dojox.mobile.ListItem Rtl*/
 .mblListItemRtl .mblListItemDeleteIcon {

--- a/mobile/themes/blackberry/Overlay.css
+++ b/mobile/themes/blackberry/Overlay.css
@@ -1,5 +1,4 @@
 @import url("../common/transitions/coverv.css");
-
 @import url("../common/transitions/revealv.css");
 /* dojox.mobile.Overlay */
 .mblOverlay {

--- a/mobile/themes/blackberry/PageIndicator.css
+++ b/mobile/themes/blackberry/PageIndicator.css
@@ -4,6 +4,7 @@
   width: 100%;
   height: 20px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblPageIndicatorContainer {
   margin-top: 4px;

--- a/mobile/themes/blackberry/RadioButton.css
+++ b/mobile/themes/blackberry/RadioButton.css
@@ -13,6 +13,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #9cacc0;

--- a/mobile/themes/blackberry/Slider.css
+++ b/mobile/themes/blackberry/Slider.css
@@ -62,4 +62,5 @@
   height: 100%;
   background-color: transparent;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }

--- a/mobile/themes/blackberry/SpinWheel.css
+++ b/mobile/themes/blackberry/SpinWheel.css
@@ -36,6 +36,7 @@
   border-left: solid 2px #000000;
   border-right: solid 2px #000000;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSpinWheelSlotLabel {
   padding: 0 8px;

--- a/mobile/themes/blackberry/Switch.css
+++ b/mobile/themes/blackberry/Switch.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   text-align: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblListItem .mblSwitch {
   position: absolute;

--- a/mobile/themes/blackberry/TabBar.css
+++ b/mobile/themes/blackberry/TabBar.css
@@ -24,6 +24,7 @@
   overflow: hidden;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   position: relative;
   list-style-type: none;
   float: left;
@@ -138,7 +139,6 @@
   color: #000000;
   background-color: #ced3ce;
   /* TODO: to compat */
-
   background-image: -webkit-gradient(linear, left top, left bottom, from(#f7fbf7), to(#cecfd6), color-stop(0.5, #ced3ce));
   background-image: linear-gradient(to bottom, #f7fbf7 0%, #ced3ce 50%, #cecfd6 100%);
 }

--- a/mobile/themes/blackberry/ToggleButton.css
+++ b/mobile/themes/blackberry/ToggleButton.css
@@ -11,6 +11,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-color: #9cacc0;
   border-radius: 6px;
   font-size: 16px;

--- a/mobile/themes/blackberry/ToolBarButton.css
+++ b/mobile/themes/blackberry/ToolBarButton.css
@@ -4,6 +4,7 @@
   position: relative;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   margin: 6px;
   padding: 0 10px;
   height: 29px;

--- a/mobile/themes/blackberry/ValuePicker.css
+++ b/mobile/themes/blackberry/ValuePicker.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayPlus.css");
-
 @import url("../common/domButtons/DomButtonGrayMinus.css");
 /* dojox.mobile.ValuePicker */
 .mblValuePicker {

--- a/mobile/themes/blackberry/View.css
+++ b/mobile/themes/blackberry/View.css
@@ -1,7 +1,5 @@
 @import url("../common/transitions/slide.css");
-
 @import url("../common/transitions/flip.css");
-
 @import url("../common/transitions/fade.css");
 /* dojox.mobile.View */
 .mblView {

--- a/mobile/themes/common/css3.less
+++ b/mobile/themes/common/css3.less
@@ -63,6 +63,7 @@
 }
 .tap-highlight-color (@v) {
 	-webkit-tap-highlight-color: @v;
+	outline-color: @v;
 }
 .text-size-adjust (@v) {
 	-webkit-text-size-adjust: @v;

--- a/mobile/themes/common/domButtons/DomButtonGrayKnob.css
+++ b/mobile/themes/common/domButtons/DomButtonGrayKnob.css
@@ -6,7 +6,6 @@
 }
 .mblDomButtonGrayKnob > div {
   /* horiz line 1 */
-
   position: absolute;
   top: 6px;
   left: 2px;
@@ -21,7 +20,6 @@
 }
 .mblDomButtonGrayKnob > div > div {
   /* horiz line 2 */
-
   position: absolute;
   top: 6px;
   width: 23px;
@@ -33,7 +31,6 @@
 }
 .mblDomButtonGrayKnob > div > div > div {
   /* horiz line 3 */
-
   position: absolute;
   top: 6px;
   width: 23px;

--- a/mobile/themes/common/domButtons/DomButtonGrayMinus.css
+++ b/mobile/themes/common/domButtons/DomButtonGrayMinus.css
@@ -6,7 +6,6 @@
 }
 .mblDomButtonGrayMinus > div {
   /* horiz line */
-
   position: absolute;
   top: 12px;
   left: 6px;

--- a/mobile/themes/common/domButtons/DomButtonGrayPlus.css
+++ b/mobile/themes/common/domButtons/DomButtonGrayPlus.css
@@ -6,7 +6,6 @@
 }
 .mblDomButtonGrayPlus > div {
   /* horiz line */
-
   position: absolute;
   top: 12px;
   left: 6px;
@@ -20,7 +19,6 @@
 }
 .mblDomButtonGrayPlus > div > div {
   /* vert line */
-
   position: absolute;
   top: -8px;
   left: 7px;

--- a/mobile/themes/common/domButtons/DomButtonWhiteMinus.css
+++ b/mobile/themes/common/domButtons/DomButtonWhiteMinus.css
@@ -6,7 +6,6 @@
 }
 .mblDomButtonWhiteMinus > div {
   /* horiz line */
-
   position: absolute;
   top: 12px;
   left: 8px;

--- a/mobile/themes/common/domButtons/DomButtonWhitePlus.css
+++ b/mobile/themes/common/domButtons/DomButtonWhitePlus.css
@@ -6,7 +6,6 @@
 }
 .mblDomButtonWhitePlus > div {
   /* horiz line */
-
   position: absolute;
   top: 12px;
   left: 8px;
@@ -19,7 +18,6 @@
 }
 .mblDomButtonWhitePlus > div > div {
   /* vert line */
-
   position: absolute;
   top: -6px;
   left: 5px;

--- a/mobile/themes/custom/Button.css
+++ b/mobile/themes/custom/Button.css
@@ -10,6 +10,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border: 1px solid #c0c0c0;
   border-bottom-color: #9b9b9b;
   border-radius: 0;

--- a/mobile/themes/custom/Carousel.css
+++ b/mobile/themes/custom/Carousel.css
@@ -27,7 +27,6 @@
   margin: 0px 2px;
   border-width: 1px;
   /* workaround for android problem */
-
 }
 .mblCarouselTitle {
   margin: 2px 0px 2px 4px;
@@ -49,6 +48,7 @@
 .mblCarouselItem {
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblCarouselItemHeaderText {
   color: white;

--- a/mobile/themes/custom/CheckBox.css
+++ b/mobile/themes/custom/CheckBox.css
@@ -12,6 +12,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border: 1px solid #c0c0c0;

--- a/mobile/themes/custom/IconContainer-compat.css
+++ b/mobile/themes/custom/IconContainer-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons-compat.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross-compat.css");
 /* dojox.mobile.IconContainer */
 .mblIconItemPaneHeading {

--- a/mobile/themes/custom/IconContainer.css
+++ b/mobile/themes/custom/IconContainer.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross.css");
 /* dojox.mobile.IconContainer */
 .mblIconContainer {
@@ -11,10 +10,10 @@
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   list-style-type: none;
   float: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblIconItemTerminator {
   list-style-type: none;

--- a/mobile/themes/custom/IconMenu.css
+++ b/mobile/themes/custom/IconMenu.css
@@ -5,6 +5,7 @@
   border-radius: 3px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   padding: 0;
   background-color: rgba(160, 160, 160, 0.85);
   border: 1px solid #000000;

--- a/mobile/themes/custom/ListItem-compat.css
+++ b/mobile/themes/custom/ListItem-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow-compat.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck-compat.css");
 /* dojox.mobile.ListItem */
 .mblListItemSelected {

--- a/mobile/themes/custom/ListItem.css
+++ b/mobile/themes/custom/ListItem.css
@@ -1,17 +1,16 @@
 @import url("../common/domButtons/DomButtonGrayArrow.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck.css");
 /* dojox.mobile.ListItem */
 .mblListItem {
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   padding: 0 8px;
   height: 43px;
   list-style-type: none;
   line-height: 43px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-bottom: 1px solid #c0c0c0;
   background-color: #ffffff;
   color: #000000;

--- a/mobile/themes/custom/ListItem_rtl.css
+++ b/mobile/themes/custom/ListItem_rtl.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow_rtl.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck_rtl.css");
 /* dojox.mobile.ListItem Rtl*/
 .mblListItemRtl .mblListItemDeleteIcon {

--- a/mobile/themes/custom/Overlay.css
+++ b/mobile/themes/custom/Overlay.css
@@ -1,5 +1,4 @@
 @import url("../common/transitions/coverv.css");
-
 @import url("../common/transitions/revealv.css");
 /* dojox.mobile.Overlay */
 .mblOverlay {

--- a/mobile/themes/custom/PageIndicator.css
+++ b/mobile/themes/custom/PageIndicator.css
@@ -4,6 +4,7 @@
   width: 100%;
   height: 20px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblPageIndicatorContainer {
   margin-top: 4px;

--- a/mobile/themes/custom/RadioButton.css
+++ b/mobile/themes/custom/RadioButton.css
@@ -13,6 +13,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-style: solid;

--- a/mobile/themes/custom/Slider.css
+++ b/mobile/themes/custom/Slider.css
@@ -64,4 +64,5 @@
   height: 100%;
   background-color: transparent;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }

--- a/mobile/themes/custom/SpinWheel.css
+++ b/mobile/themes/custom/SpinWheel.css
@@ -36,6 +36,7 @@
   border-left: solid 2px #000000;
   border-right: solid 2px #000000;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSpinWheelSlotLabel {
   padding: 0 8px;

--- a/mobile/themes/custom/Switch.css
+++ b/mobile/themes/custom/Switch.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   text-align: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblListItem .mblSwitch {
   position: absolute;

--- a/mobile/themes/custom/TabBar.css
+++ b/mobile/themes/custom/TabBar.css
@@ -24,6 +24,7 @@
   overflow: hidden;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   position: relative;
   list-style-type: none;
   float: left;

--- a/mobile/themes/custom/ToggleButton.css
+++ b/mobile/themes/custom/ToggleButton.css
@@ -11,6 +11,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border: 1px solid #c0c0c0;
   border-bottom-color: #9b9b9b;
   border-radius: 0;

--- a/mobile/themes/custom/ToolBarButton.css
+++ b/mobile/themes/custom/ToolBarButton.css
@@ -4,6 +4,7 @@
   position: relative;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   margin: 6px;
   padding: 0 10px;
   height: 29px;

--- a/mobile/themes/custom/ValuePicker.css
+++ b/mobile/themes/custom/ValuePicker.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayPlus.css");
-
 @import url("../common/domButtons/DomButtonGrayMinus.css");
 /* dojox.mobile.ValuePicker */
 .mblValuePicker {

--- a/mobile/themes/custom/View.css
+++ b/mobile/themes/custom/View.css
@@ -1,7 +1,5 @@
 @import url("../common/transitions/slide.css");
-
 @import url("../common/transitions/flip.css");
-
 @import url("../common/transitions/fade.css");
 /* dojox.mobile.View */
 .mblView {

--- a/mobile/themes/holodark/Button.css
+++ b/mobile/themes/holodark/Button.css
@@ -8,6 +8,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   background-image: none;
   background-color: #333333;
   border-style: none;

--- a/mobile/themes/holodark/Carousel.css
+++ b/mobile/themes/holodark/Carousel.css
@@ -27,7 +27,6 @@
   margin: 0px 2px;
   border-width: 1px;
   /* workaround for android problem */
-
 }
 .mblCarouselTitle {
   margin: 2px 0px 2px 4px;
@@ -49,6 +48,7 @@
 .mblCarouselItem {
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblCarouselItemHeaderText {
   color: white;

--- a/mobile/themes/holodark/CheckBox.css
+++ b/mobile/themes/holodark/CheckBox.css
@@ -15,6 +15,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #5c5c5c;

--- a/mobile/themes/holodark/IconContainer-compat.css
+++ b/mobile/themes/holodark/IconContainer-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons-compat.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross-compat.css");
 /* dojox.mobile.IconContainer */
 .mblIconItemPaneHeading {

--- a/mobile/themes/holodark/IconContainer.css
+++ b/mobile/themes/holodark/IconContainer.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross.css");
 /* dojox.mobile.IconContainer */
 .mblIconContainer {
@@ -11,10 +10,10 @@
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   list-style-type: none;
   float: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblIconItemTerminator {
   list-style-type: none;

--- a/mobile/themes/holodark/IconMenu.css
+++ b/mobile/themes/holodark/IconMenu.css
@@ -5,6 +5,7 @@
   border-radius: 6px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   padding: 0;
   background-color: rgba(64, 64, 64, 0.85);
   border: 2px solid #eeeeee;

--- a/mobile/themes/holodark/ListItem-compat.css
+++ b/mobile/themes/holodark/ListItem-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow-compat.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck-compat.css");
 /* dojox.mobile.ListItem */
 .mblListItemSelected {

--- a/mobile/themes/holodark/ListItem.css
+++ b/mobile/themes/holodark/ListItem.css
@@ -1,17 +1,16 @@
 @import url("../common/domButtons/DomButtonGrayArrow.css");
-
 @import url("../common/domButtons/DomButtonWhiteCheck.css");
 /* dojox.mobile.ListItem */
 .mblListItem {
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   padding: 0 8px;
   height: 50px;
   list-style-type: none;
   line-height: 50px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-bottom: 1px solid #333538;
   margin-right: 7px;
   margin-left: 7px;

--- a/mobile/themes/holodark/ListItem_rtl.css
+++ b/mobile/themes/holodark/ListItem_rtl.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow_rtl.css");
-
 @import url("../common/domButtons/DomButtonWhiteCheck_rtl.css");
 /* dojox.mobile.ListItem Rtl*/
 .mblListItemRtl .mblListItemDeleteIcon {

--- a/mobile/themes/holodark/Overlay.css
+++ b/mobile/themes/holodark/Overlay.css
@@ -1,5 +1,4 @@
 @import url("../common/transitions/coverv.css");
-
 @import url("../common/transitions/revealv.css");
 /* dojox.mobile.Overlay */
 .mblOverlay {

--- a/mobile/themes/holodark/PageIndicator.css
+++ b/mobile/themes/holodark/PageIndicator.css
@@ -4,6 +4,7 @@
   width: 100%;
   height: 20px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblPageIndicatorContainer {
   margin-top: 4px;

--- a/mobile/themes/holodark/RadioButton.css
+++ b/mobile/themes/holodark/RadioButton.css
@@ -18,6 +18,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #5c5c5c;

--- a/mobile/themes/holodark/Slider.css
+++ b/mobile/themes/holodark/Slider.css
@@ -61,6 +61,7 @@
   height: 100%;
   background-color: transparent;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSlider {
   border-style: none;

--- a/mobile/themes/holodark/SpinWheel.css
+++ b/mobile/themes/holodark/SpinWheel.css
@@ -36,6 +36,7 @@
   border-left: solid 2px #000000;
   border-right: solid 2px #000000;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSpinWheelSlotLabel {
   padding: 0 8px;

--- a/mobile/themes/holodark/Switch.css
+++ b/mobile/themes/holodark/Switch.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   text-align: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblListItem .mblSwitch {
   position: absolute;

--- a/mobile/themes/holodark/TabBar.css
+++ b/mobile/themes/holodark/TabBar.css
@@ -25,6 +25,7 @@
   overflow: hidden;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   position: relative;
   list-style-type: none;
   float: left;
@@ -156,7 +157,6 @@
   color: #ffffff;
   background-color: #333333;
   /* TODO: to compat */
-
   background-image: none;
 }
 .mblTabBarStandardTab .mblTabBarButtonIconArea {
@@ -174,7 +174,6 @@
   color: #ffffff;
   background-color: #33b5e5;
   /* TODO: to compat */
-
   background-image: -webkit-gradient(linear, left top, left bottom, from(#313031), to(#959595), color-stop(0.5, #5a555a), color-stop(0.5, #616161));
   background-image: linear-gradient(to bottom, #313031 0%, #5a555a 50%, #616161 50%, #959595 100%);
 }
@@ -297,7 +296,6 @@
 @media (max-width: 500px) {
   .mblTabBarTabBar {
     /* Tab separator only for width < 500 (because TabBar._largeScreenWidth == 500)*/
-  
   }
   .mblTabBarTabBar .mblTabBarButton + .mblTabBarButton:before {
     content: url('images/vseparator.png');

--- a/mobile/themes/holodark/ToggleButton.css
+++ b/mobile/themes/holodark/ToggleButton.css
@@ -9,6 +9,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   background-image: none;
   background-color: #333333;
   border-style: none;

--- a/mobile/themes/holodark/ToolBarButton.css
+++ b/mobile/themes/holodark/ToolBarButton.css
@@ -4,6 +4,7 @@
   position: relative;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   margin: 6px;
   padding: 0 10px;
   height: 29px;

--- a/mobile/themes/holodark/ValuePicker.css
+++ b/mobile/themes/holodark/ValuePicker.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayPlus.css");
-
 @import url("../common/domButtons/DomButtonGrayMinus.css");
 /* dojox.mobile.ValuePicker */
 .mblValuePicker {

--- a/mobile/themes/holodark/View.css
+++ b/mobile/themes/holodark/View.css
@@ -1,7 +1,5 @@
 @import url("../common/transitions/slide.css");
-
 @import url("../common/transitions/flip.css");
-
 @import url("../common/transitions/fade.css");
 /* dojox.mobile.View */
 .mblView {

--- a/mobile/themes/ios7/Button.css
+++ b/mobile/themes/ios7/Button.css
@@ -8,6 +8,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   background-image: none;
   background-color: rgba(0, 0, 0, 0);
   border-style: none;

--- a/mobile/themes/ios7/Carousel.css
+++ b/mobile/themes/ios7/Carousel.css
@@ -27,7 +27,6 @@
   margin: 0px 2px;
   border-width: 1px;
   /* workaround for android problem */
-
 }
 .mblCarouselTitle {
   margin: 2px 0px 2px 4px;
@@ -49,6 +48,7 @@
 .mblCarouselItem {
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblCarouselItemHeaderText {
   color: white;

--- a/mobile/themes/ios7/CheckBox.css
+++ b/mobile/themes/ios7/CheckBox.css
@@ -11,6 +11,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #5c5c5c;

--- a/mobile/themes/ios7/IconContainer-compat.css
+++ b/mobile/themes/ios7/IconContainer-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons-compat.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross-compat.css");
 /* dojox.mobile.IconContainer */
 .mblIconItemPaneHeading {

--- a/mobile/themes/ios7/IconContainer.css
+++ b/mobile/themes/ios7/IconContainer.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross.css");
 /* dojox.mobile.IconContainer */
 .mblIconContainer {
@@ -11,10 +10,10 @@
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   list-style-type: none;
   float: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblIconItemTerminator {
   list-style-type: none;

--- a/mobile/themes/ios7/IconMenu.css
+++ b/mobile/themes/ios7/IconMenu.css
@@ -5,6 +5,7 @@
   border-radius: 6px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   padding: 0;
   background-color: rgba(200, 200, 200, 0.45);
   border: 1px solid #007aff;

--- a/mobile/themes/ios7/ListItem-compat.css
+++ b/mobile/themes/ios7/ListItem-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow-compat.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck-compat.css");
 /* dojox.mobile.ListItem */
 .mblListItemSelected {

--- a/mobile/themes/ios7/ListItem.css
+++ b/mobile/themes/ios7/ListItem.css
@@ -1,17 +1,16 @@
 @import url("../common/domButtons/DomButtonGrayArrow.css");
-
 @import url("../common/domButtons/DomButtonWhiteCheck.css");
 /* dojox.mobile.ListItem */
 .mblListItem {
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   padding: 0 8px;
   height: 50px;
   list-style-type: none;
   line-height: 50px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-bottom: 1px solid #C8C7CC;
   margin-left: 0px;
   margin-right: 0px;

--- a/mobile/themes/ios7/ListItem_rtl.css
+++ b/mobile/themes/ios7/ListItem_rtl.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow_rtl.css");
-
 @import url("../common/domButtons/DomButtonWhiteCheck_rtl.css");
 /* dojox.mobile.ListItem Rtl*/
 .mblListItemRtl .mblListItemDeleteIcon {

--- a/mobile/themes/ios7/Overlay.css
+++ b/mobile/themes/ios7/Overlay.css
@@ -1,5 +1,4 @@
 @import url("../common/transitions/coverv.css");
-
 @import url("../common/transitions/revealv.css");
 /* dojox.mobile.Overlay */
 .mblOverlay {

--- a/mobile/themes/ios7/PageIndicator.css
+++ b/mobile/themes/ios7/PageIndicator.css
@@ -4,6 +4,7 @@
   width: 100%;
   height: 20px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblPageIndicatorContainer {
   margin-top: 4px;

--- a/mobile/themes/ios7/RadioButton.css
+++ b/mobile/themes/ios7/RadioButton.css
@@ -14,6 +14,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #5c5c5c;

--- a/mobile/themes/ios7/Slider.css
+++ b/mobile/themes/ios7/Slider.css
@@ -60,6 +60,7 @@
   height: 100%;
   background-color: transparent;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSlider {
   border-style: none;

--- a/mobile/themes/ios7/SpinWheel-compat.css
+++ b/mobile/themes/ios7/SpinWheel-compat.css
@@ -36,6 +36,7 @@
   border-left: solid 2px #000000;
   border-right: solid 2px #000000;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSpinWheelSlotLabel {
   padding: 0 8px;

--- a/mobile/themes/ios7/SpinWheel.css
+++ b/mobile/themes/ios7/SpinWheel.css
@@ -36,6 +36,7 @@
   border-left: solid 2px #000000;
   border-right: solid 2px #000000;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSpinWheelSlotLabel {
   padding: 0 8px;

--- a/mobile/themes/ios7/Switch.css
+++ b/mobile/themes/ios7/Switch.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   text-align: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblListItem .mblSwitch {
   position: absolute;

--- a/mobile/themes/ios7/TabBar-compat.css
+++ b/mobile/themes/ios7/TabBar-compat.css
@@ -23,6 +23,7 @@
   overflow: hidden;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   position: relative;
   list-style-type: none;
   float: left;

--- a/mobile/themes/ios7/TabBar.css
+++ b/mobile/themes/ios7/TabBar.css
@@ -23,6 +23,7 @@
   overflow: hidden;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   position: relative;
   list-style-type: none;
   float: left;

--- a/mobile/themes/ios7/ToggleButton.css
+++ b/mobile/themes/ios7/ToggleButton.css
@@ -9,6 +9,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   background-image: none;
   background-color: rgba(0, 0, 0, 0);
   border-style: none;

--- a/mobile/themes/ios7/ToolBarButton.css
+++ b/mobile/themes/ios7/ToolBarButton.css
@@ -4,6 +4,7 @@
   position: relative;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   margin: 6px;
   padding: 0 10px;
   height: 29px;

--- a/mobile/themes/ios7/ValuePicker.css
+++ b/mobile/themes/ios7/ValuePicker.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayPlus.css");
-
 @import url("../common/domButtons/DomButtonGrayMinus.css");
 /* dojox.mobile.ValuePicker */
 .mblValuePicker {

--- a/mobile/themes/ios7/View.css
+++ b/mobile/themes/ios7/View.css
@@ -1,7 +1,5 @@
 @import url("../common/transitions/slide.css");
-
 @import url("../common/transitions/flip.css");
-
 @import url("../common/transitions/fade.css");
 /* dojox.mobile.View */
 .mblView {

--- a/mobile/themes/iphone/Button.css
+++ b/mobile/themes/iphone/Button.css
@@ -10,6 +10,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-color: #9cacc0;
   border-radius: 5px;
   color: black;

--- a/mobile/themes/iphone/Carousel.css
+++ b/mobile/themes/iphone/Carousel.css
@@ -27,7 +27,6 @@
   margin: 0px 2px;
   border-width: 1px;
   /* workaround for android problem */
-
 }
 .mblCarouselTitle {
   margin: 2px 0px 2px 4px;
@@ -49,6 +48,7 @@
 .mblCarouselItem {
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblCarouselItemHeaderText {
   color: white;

--- a/mobile/themes/iphone/CheckBox.css
+++ b/mobile/themes/iphone/CheckBox.css
@@ -12,6 +12,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #9cacc0;

--- a/mobile/themes/iphone/IconContainer-compat.css
+++ b/mobile/themes/iphone/IconContainer-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons-compat.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross-compat.css");
 /* dojox.mobile.IconContainer */
 .mblIconItemPaneHeading {

--- a/mobile/themes/iphone/IconContainer.css
+++ b/mobile/themes/iphone/IconContainer.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross.css");
 /* dojox.mobile.IconContainer */
 .mblIconContainer {
@@ -11,10 +10,10 @@
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   list-style-type: none;
   float: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblIconItemTerminator {
   list-style-type: none;

--- a/mobile/themes/iphone/IconMenu.css
+++ b/mobile/themes/iphone/IconMenu.css
@@ -5,6 +5,7 @@
   border-radius: 10px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   padding: 0;
   background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(102, 102, 119, 0.85)), to(rgba(4, 4, 4, 0.85)), color-stop(0.35, rgba(22, 22, 30, 0.85)));
   background-image: linear-gradient(to bottom, rgba(102, 102, 119, 0.85) 0%, rgba(22, 22, 30, 0.85) 35%, rgba(4, 4, 4, 0.85) 100%);

--- a/mobile/themes/iphone/ListItem-compat.css
+++ b/mobile/themes/iphone/ListItem-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow-compat.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck-compat.css");
 /* dojox.mobile.ListItem */
 .mblListItemSelected {

--- a/mobile/themes/iphone/ListItem.css
+++ b/mobile/themes/iphone/ListItem.css
@@ -1,17 +1,16 @@
 @import url("../common/domButtons/DomButtonGrayArrow.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck.css");
 /* dojox.mobile.ListItem */
 .mblListItem {
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   padding: 0 8px;
   height: 43px;
   list-style-type: none;
   line-height: 43px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-bottom: 1px solid #adaaad;
   font-weight: bold;
   color: black;
@@ -122,6 +121,5 @@
 }
 .dj_ios6 .mblListItem {
   /* enables hardware acc. to avoid flickering issues - see #16956 */
-
   -webkit-perspective: 1000;
 }

--- a/mobile/themes/iphone/ListItem_rtl.css
+++ b/mobile/themes/iphone/ListItem_rtl.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow_rtl.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck_rtl.css");
 /* dojox.mobile.ListItem Rtl*/
 .mblListItemRtl .mblListItemDeleteIcon {

--- a/mobile/themes/iphone/Overlay.css
+++ b/mobile/themes/iphone/Overlay.css
@@ -1,5 +1,4 @@
 @import url("../common/transitions/coverv.css");
-
 @import url("../common/transitions/revealv.css");
 /* dojox.mobile.Overlay */
 .mblOverlay {

--- a/mobile/themes/iphone/PageIndicator.css
+++ b/mobile/themes/iphone/PageIndicator.css
@@ -4,6 +4,7 @@
   width: 100%;
   height: 20px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblPageIndicatorContainer {
   margin-top: 4px;

--- a/mobile/themes/iphone/RadioButton.css
+++ b/mobile/themes/iphone/RadioButton.css
@@ -13,6 +13,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border-color: #9cacc0;

--- a/mobile/themes/iphone/Slider.css
+++ b/mobile/themes/iphone/Slider.css
@@ -62,4 +62,5 @@
   height: 100%;
   background-color: transparent;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }

--- a/mobile/themes/iphone/SpinWheel.css
+++ b/mobile/themes/iphone/SpinWheel.css
@@ -36,6 +36,7 @@
   border-left: solid 2px #000000;
   border-right: solid 2px #000000;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSpinWheelSlotLabel {
   padding: 0 8px;

--- a/mobile/themes/iphone/Switch.css
+++ b/mobile/themes/iphone/Switch.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   text-align: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblListItem .mblSwitch {
   position: absolute;

--- a/mobile/themes/iphone/TabBar.css
+++ b/mobile/themes/iphone/TabBar.css
@@ -24,6 +24,7 @@
   overflow: hidden;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   position: relative;
   list-style-type: none;
   float: left;

--- a/mobile/themes/iphone/ToggleButton.css
+++ b/mobile/themes/iphone/ToggleButton.css
@@ -11,6 +11,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border-color: #9cacc0;
   border-radius: 5px;
   font-size: 13px;

--- a/mobile/themes/iphone/ToolBarButton.css
+++ b/mobile/themes/iphone/ToolBarButton.css
@@ -4,6 +4,7 @@
   position: relative;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   margin: 6px;
   padding: 0 10px;
   height: 29px;

--- a/mobile/themes/iphone/ValuePicker.css
+++ b/mobile/themes/iphone/ValuePicker.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayPlus.css");
-
 @import url("../common/domButtons/DomButtonGrayMinus.css");
 /* dojox.mobile.ValuePicker */
 .mblValuePicker {

--- a/mobile/themes/iphone/View.css
+++ b/mobile/themes/iphone/View.css
@@ -1,7 +1,5 @@
 @import url("../common/transitions/slide.css");
-
 @import url("../common/transitions/flip.css");
-
 @import url("../common/transitions/fade.css");
 /* dojox.mobile.View */
 .mblView {

--- a/mobile/themes/windows/Button.css
+++ b/mobile/themes/windows/Button.css
@@ -8,6 +8,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border: 2px solid #ffffff;
   border-radius: 0;
   margin-top: 8px;

--- a/mobile/themes/windows/Carousel.css
+++ b/mobile/themes/windows/Carousel.css
@@ -27,7 +27,6 @@
   margin: 0px 2px;
   border-width: 1px;
   /* workaround for android problem */
-
 }
 .mblCarouselTitle {
   margin: 2px 0px 2px 4px;
@@ -49,6 +48,7 @@
 .mblCarouselItem {
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblCarouselItemHeaderText {
   color: white;

--- a/mobile/themes/windows/CheckBox.css
+++ b/mobile/themes/windows/CheckBox.css
@@ -10,6 +10,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   border: 2px solid #ffffff;

--- a/mobile/themes/windows/IconContainer-compat.css
+++ b/mobile/themes/windows/IconContainer-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonColorButtons-compat.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross-compat.css");
 /* dojox.mobile.IconContainer */
 .mblIconItemPaneHeading {

--- a/mobile/themes/windows/IconContainer.css
+++ b/mobile/themes/windows/IconContainer.css
@@ -1,7 +1,5 @@
 @import url("../common/domButtons/DomButtonColorButtons.css");
-
 @import url("../common/domButtons/DomButtonBlackCircleCross.css");
-
 @import url("../common/IconContainer_keyframes.css");
 /* dojox.mobile.IconContainer */
 .mblIconContainer {
@@ -13,10 +11,10 @@
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   list-style-type: none;
   float: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblIconItemTerminator {
   list-style-type: none;

--- a/mobile/themes/windows/IconMenu.css
+++ b/mobile/themes/windows/IconMenu.css
@@ -5,6 +5,7 @@
   border-radius: 3px;
   text-align: center;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   padding: 0;
   background-color: rgba(160, 160, 160, 0.85);
   border: 1px solid #869cbf;

--- a/mobile/themes/windows/ListItem-compat.css
+++ b/mobile/themes/windows/ListItem-compat.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayArrow-compat.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck-compat.css");
 /* dojox.mobile.ListItem */
 .mblListItemSelected {

--- a/mobile/themes/windows/ListItem.css
+++ b/mobile/themes/windows/ListItem.css
@@ -1,17 +1,16 @@
 @import url("../common/domButtons/DomButtonGrayArrow.css");
-
 @import url("../common/domButtons/DomButtonDarkBlueCheck.css");
 /* dojox.mobile.ListItem */
 .mblListItem {
   position: relative;
   overflow: hidden;
   /* for focus frame */
-
   padding: 0 8px;
   height: 43px;
   list-style-type: none;
   line-height: 43px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   border: none;
   background-color: transparent;
   color: #ffffff;

--- a/mobile/themes/windows/Overlay.css
+++ b/mobile/themes/windows/Overlay.css
@@ -1,5 +1,4 @@
 @import url("../common/transitions/coverv.css");
-
 @import url("../common/transitions/revealv.css");
 /* dojox.mobile.Overlay */
 .mblOverlay {

--- a/mobile/themes/windows/PageIndicator.css
+++ b/mobile/themes/windows/PageIndicator.css
@@ -4,6 +4,7 @@
   width: 100%;
   height: 20px;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblPageIndicatorContainer {
   margin-top: 4px;

--- a/mobile/themes/windows/RadioButton.css
+++ b/mobile/themes/windows/RadioButton.css
@@ -11,6 +11,7 @@
   cursor: pointer;
   -webkit-appearance: none;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   -webkit-transform: translateY(0.45em);
   transform: translateY(0.45em);
   opacity: 0;

--- a/mobile/themes/windows/Slider.css
+++ b/mobile/themes/windows/Slider.css
@@ -61,6 +61,7 @@
   height: 100%;
   background-color: transparent;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSlider > div:before {
   content: '';

--- a/mobile/themes/windows/SpinWheel.css
+++ b/mobile/themes/windows/SpinWheel.css
@@ -36,6 +36,7 @@
   border-left: solid 2px #000000;
   border-right: solid 2px #000000;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblSpinWheelSlotLabel {
   padding: 0 8px;

--- a/mobile/themes/windows/Switch.css
+++ b/mobile/themes/windows/Switch.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   text-align: left;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
 }
 .mblListItem .mblSwitch {
   position: absolute;

--- a/mobile/themes/windows/TabBar.css
+++ b/mobile/themes/windows/TabBar.css
@@ -24,6 +24,7 @@
   overflow: hidden;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   position: relative;
   list-style-type: none;
   float: left;

--- a/mobile/themes/windows/ToggleButton.css
+++ b/mobile/themes/windows/ToggleButton.css
@@ -9,6 +9,7 @@
   line-height: 29px;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   margin-top: 8px;
   margin-bottom: 8px;
   margin-left: 0px!important;

--- a/mobile/themes/windows/ToolBarButton.css
+++ b/mobile/themes/windows/ToolBarButton.css
@@ -4,6 +4,7 @@
   position: relative;
   cursor: pointer;
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  outline-color: rgba(255, 255, 255, 0);
   margin: 6px;
   padding: 0 10px;
   height: 29px;

--- a/mobile/themes/windows/ValuePicker.css
+++ b/mobile/themes/windows/ValuePicker.css
@@ -1,5 +1,4 @@
 @import url("../common/domButtons/DomButtonGrayPlus.css");
-
 @import url("../common/domButtons/DomButtonGrayMinus.css");
 /* dojox.mobile.ValuePicker */
 .mblValuePicker {

--- a/mobile/themes/windows/View.css
+++ b/mobile/themes/windows/View.css
@@ -1,7 +1,5 @@
 @import url("../common/transitions/slide.css");
-
 @import url("../common/transitions/flip.css");
-
 @import url("../common/transitions/fade.css");
 /* dojox.mobile.View */
 .mblView {


### PR DESCRIPTION
There is an orange outline on focused elements in Android. This fix assumes that when tap-highlight-color is set, the outline color should be set to the same, clearing up the issue on Android. Fixes [#18357](https://bugs.dojotoolkit.org/ticket/18357).

![Android button focus highlight](https://cloud.githubusercontent.com/assets/293805/4945017/4492b2e0-6603-11e4-92e2-bf8fedcdac40.png)
