### PR TITLE
[cla] Fix: change to RangeSlider never fires `watch` callbacks

### DIFF
--- a/form/_RangeSliderMixin.js
+++ b/form/_RangeSliderMixin.js
@@ -217,7 +217,9 @@ define([
 
 		_setValueAttr: function(/*Array or Number*/ value, /*Boolean, optional*/ priorityChange, /*Boolean, optional*/ isMaxVal){
 			// we pass an array, when we move the slider with the bar
-			var actValue = this.value;
+			//var actValue = this.value;
+			var actValue = lang.clone(this.value);
+
 			if(!lang.isArray(value)){
 				if(isMaxVal){
 					if(this._isReversed()){
@@ -237,15 +239,18 @@ define([
 			}
 			// we have to reset this values. don't know the reason for that
 			this._lastValueReported = "";
-			this.valueNode.value = this.value = value = actValue;
+			//this.valueNode.value = this.value = value = actValue;
+			this.valueNode.value = value = actValue;
 
-			this.value.sort(this._isReversed() ? sortReversed : sortForward);
+			//this.value.sort(this._isReversed() ? sortReversed : sortForward);
+			actValue.sort(this._isReversed() ? sortReversed : sortForward);
 
 			this.sliderHandle.setAttribute("aria-valuenow", actValue[0]);
 			this.sliderHandleMax.setAttribute("aria-valuenow", actValue[1]);
 			
 			// not calling the _setValueAttr-function of Slider, but the super-super-class (needed for the onchange-event!)
 			FormValueWidget.prototype._setValueAttr.apply(this, arguments);
+
 			this._printSliderBar(priorityChange, isMaxVal);
 		},
 

--- a/form/_RangeSliderMixin.js
+++ b/form/_RangeSliderMixin.js
@@ -217,7 +217,6 @@ define([
 
 		_setValueAttr: function(/*Array or Number*/ value, /*Boolean, optional*/ priorityChange, /*Boolean, optional*/ isMaxVal){
 			// we pass an array, when we move the slider with the bar
-			//var actValue = this.value;
 			var actValue = lang.clone(this.value);
 
 			if(!lang.isArray(value)){
@@ -239,10 +238,8 @@ define([
 			}
 			// we have to reset this values. don't know the reason for that
 			this._lastValueReported = "";
-			//this.valueNode.value = this.value = value = actValue;
 			this.valueNode.value = value = actValue;
 
-			//this.value.sort(this._isReversed() ? sortReversed : sortForward);
 			actValue.sort(this._isReversed() ? sortReversed : sortForward);
 
 			this.sliderHandle.setAttribute("aria-valuenow", actValue[0]);

--- a/form/tests/test_RangeSlider.html
+++ b/form/tests/test_RangeSlider.html
@@ -152,6 +152,16 @@
 							var v2 = slider.get('value');
 							doh.is(v[0], v2[0], "min unchanged");
 							doh.is(v[1], v2[1], "max unchanged");
+						},
+						function watchValue(){
+							var slider = registry.byId('watchSlider'),
+								v;
+							slider.watch('value', function(value, oldValue, newValue){
+								v = newValue;
+							});
+							slider.set('value', [slider.minimum+30, slider.maximum-30], true);
+							doh.is(slider.minimum+30, v[0], "min value " + v[0]);
+							doh.is(slider.maximum-30, v[1], "max value " + v[1]);
 						}
 					]);
 					doh.register("disable", [
@@ -200,6 +210,21 @@
 		<div dojoType="dijit/form/HorizontalRule" container="topDecoration" count=7 style="height:10px;margin-bottom:-5px;"></div>
 	</div>
 	</center>
+
+	<h2>Watch slider</h2>
+	<center>
+	<div 
+		id="watchSlider" 
+		discreteValues="11"
+		onChange="horizOnChange"
+		style="width:500px;" 
+		value="80,20" 
+		intermediateChanges="true"
+		dojoType="dojox/form/HorizontalRangeSlider">
+		<ol dojoType="dijit/form/HorizontalRuleLabels" container="topDecoration" style="height:1.2em;font-size:75%;color:gray;" count="7" constraints="{pattern:'#.00%'}"></ol>
+		<div dojoType="dijit/form/HorizontalRule" container="topDecoration" count=7 style="height:10px;margin-bottom:-5px;"></div>
+	</div>
+	</center>
 	<label for="minValue">Horizontal Slider Min Value:</label><input readonly id="minValue" size="10" value="20.0%"/><br/>
 	<label for="maxValue">Horizontal Slider Max Value:</label><input readonly id="maxValue" size="10" value="80.0%"/><br/>
 	<button id="disableButton" dojoType="dijit/form/Button" onClick="registry.byId('hrSlider').set('disabled', true);registry.byId('disableButton').set('disabled',true);registry.byId('enableButton').set('disabled',false);">Disable previous slider</button>
@@ -228,6 +253,7 @@
 		<div dojoType="dijit/form/VerticalRule" container="rightDecoration" count=11 style="width:5px;" ruleStyle="border-color:gray;"></div>
 		<ol dojoType="dijit/form/VerticalRuleLabels" data-dojo-props='container:"rightDecoration", style:{width:"2em"}, count:6, numericMargin:1, minimum:0, maximum:100, constraints:{pattern:"#"}'></ol>
 	</div>
+
 	<p>
 	<label for="vMaxValue">Vertical Slider Max Value:</label><input readonly id="vMaxValue" size="10" value="90.0"/><br/>
 	<label for="vMinValue">Vertical Slider Min Value:</label><input readonly id="vMinValue" size="10" value="10.0"/><br/>


### PR DESCRIPTION
Fixes ticket #18381. `RangeSlider#value` is reset before the `_set` method is called, with the result that
callbacks registered with `watch` are never fired, as `_set` requires that the old
and new values differ before firing `_watchCallbacks`.