### PR TITLE
Gfx toSVG fix for pie chart on IE8

### DIFF
--- a/gfx/utils.js
+++ b/gfx/utils.js
@@ -85,6 +85,9 @@ define(["dojo/_base/kernel","dojo/_base/lang","./_base", "dojo/_base/html","dojo
 				return arr.map(object, lang.hitch(null, gu.deserialize, parent));	// Array
 			}
 			var shape = ("shape" in object) ? parent.createShape(object.shape) : parent.createGroup();
+                        if (null === shape && "path" in  object.shape) {
+                            shape = parent.createPath(object.shape.path);
+                        }
 			if("transform" in object){
 				shape.setTransform(object.transform);
 			}


### PR DESCRIPTION
toSVG is broken on IE8 for pie charts (works fine for other types of charts), minimal example - https://gist.github.com/alexkasko/f42618dc5077944be5d6

For some reason `object.shape` has no `type` attribute for pie chart slices in `utils.js#deserialize` so `parent.createShape(...)` returns `null` for the slices. Workaround is to check for `null` result and create path directly.

Note, the problem is not related to cross-domain/iframe as the full dojo is served from the same server.

Error on IE8:

    Webpage error details

    User Agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)
    Timestamp: Wed, 26 Nov 2014 10:42:39 UTC


    Message: 'null' is null or not an object
    Line: 1
    Char: 1
    Code: 0
    URI: http://192.168.42.2:8000/dojo-latest/dojox/gfx/resources/gfxSvgProxyFrame.html


