### PR TITLE
Fix text selection issues with dojox/mdnd/Moveable

### DIFF
--- a/mdnd/Moveable.js
+++ b/mdnd/Moveable.js
@@ -208,6 +208,8 @@ define([
 			}
 			connect.disconnect(this.events.pop());
 			connect.disconnect(this.events.pop());
+			connect.disconnect(this._selectStart);
+			this._selectStart = null;
 		},
 		
 		onDragStart: function(/*DOMNode*/node, /*Object*/coords, /*Object*/size){


### PR DESCRIPTION
On mousedown, dojox/mdnd/Moveable prevents text selection on the body,
but never clears this handle, so text selection is no longer available. refs:[#18397](https://bugs.dojotoolkit.org/ticket/18397)
