### PR TITLE
Socket reconnect

### DIFF
--- a/socket/Reconnect.js
+++ b/socket/Reconnect.js
@@ -16,9 +16,10 @@ define([
 		//		|    var socket = dxSocket({url:"/comet"});
 		//		|    // add auto-reconnect support
 		//		|    socket = reconnect(socket);
+		options = options || {};
+
 		var reconnectTime = options.reconnectTime || 10000;
 		var checkForOpen, newSocket;
-		options = options || {};
 
 		aspect.after(socket, "onclose", function(event){
 			clearTimeout(checkForOpen);

--- a/socket/Reconnect.js
+++ b/socket/Reconnect.js
@@ -19,6 +19,8 @@ define([
 		options = options || {};
 
 		var reconnectTime = options.reconnectTime || 10000;
+		var backoffRate = options.backoffRate || 2;
+		var timeout = reconnectTime;
 		var checkForOpen, newSocket;
 
 		aspect.after(socket, "onclose", function(event){
@@ -37,12 +39,12 @@ define([
 					checkForOpen = setTimeout(function(){
 						//reset the backoff
 						if(newSocket.readyState < 2){
-							reconnectTime = options.reconnectTime || 10000;
+							timeout = reconnectTime;
 						}
-					}, 10000);
-				}, reconnectTime);
+					}, reconnectTime);
+				}, timeout);
 				// backoff each time
-				reconnectTime *= options.backoffRate || 2;
+				timeout *= backoffRate;
 			};
 		}
 		if(!socket.reconnect){


### PR DESCRIPTION
this PR makes the following changes:
* prevents failures caused when not providing options for reconnect
* uses `options.reconnectTime` as the timeout for `checkForOpen`

@Kagetsume since you seem to also have an interest in this module, you want to review my changes for me?