### PR TITLE
fixes:#18430 Keep RTL RangeSlider value consistent

### DIFF
--- a/form/_RangeSliderMixin.js
+++ b/form/_RangeSliderMixin.js
@@ -19,8 +19,7 @@ define([
 
 	// make these functions once:
 	var sortReversed = function(a, b){ return b - a; },
-		sortForward = function(a, b){ return a - b; }
-	;
+		sortForward = function(a, b){ return a - b; };
 
 
 	var RangeSliderMixin = declare("dojox.form._RangeSliderMixin", null, {
@@ -38,7 +37,7 @@ define([
 			this.inherited(arguments);
 			// we sort the values!
 			// TODO: re-think, how to set the value
-			this.value.sort(this._isReversed() ? sortReversed : sortForward);
+			this.value.sort(sortForward);
 
 			// define a custom constructor for a SliderMoverMax that points back to me
 			var _self = this;
@@ -53,13 +52,13 @@ define([
 			//The valuenow of the sliderHandle (min) usually determines the valuemin of sliderHandleMax
 			//and valuenow of sliderHandleMax usually determines the valueMax of sliderHandle
 			//However, in our RangeSlider dragging one handle past the other one causes both to
-			//'snap' together and move so both sliders will have the same min, max values			
+			//'snap' together and move so both sliders will have the same min, max values
 
 			this.sliderHandle.setAttribute("aria-valuemin", this.minimum);
 			this.sliderHandle.setAttribute("aria-valuemax", this.maximum);
 			this.sliderHandleMax.setAttribute("aria-valuemin", this.minimum);
 			this.sliderHandleMax.setAttribute("aria-valuemax", this.maximum);
-			
+
 			// a dnd for the bar!
 			var barMover = declare(SliderBarMover, {
 				constructor: function(){
@@ -67,13 +66,13 @@ define([
 				}
 			});
 			this._movableBar = new Moveable(this.progressBar,{ mover: barMover });
-				
+
 			// Remove these from the progress bar since it isn't a slider
 			this.focusNode.removeAttribute("aria-valuemin");
 			this.focusNode.removeAttribute("aria-valuemax");
 			this.focusNode.removeAttribute("aria-valuenow");
 
-		},		
+		},
 
 		destroy: function(){
 			this.inherited(arguments);
@@ -86,8 +85,8 @@ define([
 
 			var useMaxValue = e.target === this.sliderHandleMax;
 			var barFocus = e.target === this.progressBar;
-			var k = lang.delegate(keys, this.isLeftToRight() ? {PREV_ARROW: keys.LEFT_ARROW, NEXT_ARROW: keys.RIGHT_ARROW} 
-			                                                 : {PREV_ARROW: keys.RIGHT_ARROW, NEXT_ARROW: keys.LEFT_ARROW});			
+			var k = lang.delegate(keys, this.isLeftToRight() ? {PREV_ARROW: keys.LEFT_ARROW, NEXT_ARROW: keys.RIGHT_ARROW}
+			                                                 : {PREV_ARROW: keys.RIGHT_ARROW, NEXT_ARROW: keys.LEFT_ARROW});
 			var delta = 0;
 			var down = false;
 
@@ -102,7 +101,7 @@ define([
 				case k.PAGE_UP    :	delta = this.pageIncrement; break;
 				default           : this.inherited(arguments);return;
 			}
-			
+
 			if(down){delta = -delta;}
 
 			if(delta){
@@ -139,7 +138,7 @@ define([
 					this._getBumpValue(signedChange[0].change, signedChange[0].useMaxValue),
 					this._getBumpValue(signedChange[1].change, signedChange[1].useMaxValue)
 				]
-				: this._getBumpValue(signedChange, useMaxValue)
+				: this._getBumpValue(signedChange, useMaxValue);
 
 			this._setValueAttr(value, true, useMaxValue);
 		},
@@ -147,9 +146,6 @@ define([
 		_getBumpValue: function(signedChange, useMaxValue){
 
 			var idx = useMaxValue ? 1 : 0;
-			if(this._isReversed()){
-				idx = 1 - idx;
-			}
 
 			var s = domStyle.getComputedStyle(this.sliderBarContainer),
 				c = domGeometry.getContentBox(this.sliderBarContainer, s),
@@ -219,19 +215,7 @@ define([
 			// we pass an array, when we move the slider with the bar
 			var actValue = this.value;
 			if(!lang.isArray(value)){
-				if(isMaxVal){
-					if(this._isReversed()){
-						actValue[0] = value;
-					}else{
-						actValue[1] = value;
-					}
-				}else{
-					if(this._isReversed()){
-						actValue[1] = value;
-					}else{
-						actValue[0] = value;
-					}
-				}
+				actValue[isMaxVal ? 1 : 0] = value;
 			}else{
 				actValue = value;
 			}
@@ -239,11 +223,11 @@ define([
 			this._lastValueReported = "";
 			this.valueNode.value = this.value = value = actValue;
 
-			this.value.sort(this._isReversed() ? sortReversed : sortForward);
+			this.value.sort(sortForward);
 
 			this.sliderHandle.setAttribute("aria-valuenow", actValue[0]);
 			this.sliderHandleMax.setAttribute("aria-valuenow", actValue[1]);
-			
+
 			// not calling the _setValueAttr-function of Slider, but the super-super-class (needed for the onchange-event!)
 			FormValueWidget.prototype._setValueAttr.apply(this, arguments);
 			this._printSliderBar(priorityChange, isMaxVal);

--- a/form/tests/test_RangeSlider.html
+++ b/form/tests/test_RangeSlider.html
@@ -61,11 +61,18 @@
 
 			}
 
+			horizRtlOnChange = function(){
+
+				dom.byId('minValueRtl').value = number.format(arguments[0][0]/100, { places:1, pattern:'#%' });
+				dom.byId('maxValueRtl').value = number.format(arguments[0][1]/100, { places:1, pattern:'#%' });
+
+			}
+
 			vertOnChange = function(){
 
 				console.log(arguments);
-				dom.byId('vMinValue').value = number.format(arguments[0][1],{places:1,pattern:'#'});
-				dom.byId('vMaxValue').value = number.format(arguments[0][0],{places:1,pattern:'#'});
+				dom.byId('vMinValue').value = number.format(arguments[0][0],{places:1,pattern:'#'});
+				dom.byId('vMaxValue').value = number.format(arguments[0][1],{places:1,pattern:'#'});
 
 			}
 
@@ -91,12 +98,19 @@
 							doh.is(slider.minimum+30, v[0], "min value " + v[0]);
 							doh.is(slider.maximum-30, v[1], "max value " + v[1]);
 						},
+						function setHValueRtl(){
+							var slider = registry.byId("hrSliderRtl");
+							slider.set('value', [slider.minimum+30, slider.maximum-30], true);
+							var v = slider.get('value').concat([]); // copy array
+							doh.is(slider.minimum+30, v[0], "min value " + v[0]);
+							doh.is(slider.maximum-30, v[1], "max value " + v[1]);
+						},
 						function setVValue(){
 							var slider = registry.byId("vrSlider");
 							slider.set('value', [slider.minimum+30, slider.maximum-30], true);
 							var v = slider.get('value').concat([]); // copy array
-							doh.is(slider.maximum-30, v[0], "max value " + v[0]);
-							doh.is(slider.minimum+30, v[1], "min value " + v[1]);
+							doh.is(slider.maximum-30, v[1], "max value " + v[1]);
+							doh.is(slider.minimum+30, v[0], "min value " + v[0]);
 						},
 						function clickHValue(){
 							var slider = registry.byId("hrSlider");
@@ -113,10 +127,10 @@
 							var bar = domGeometry.position(slider.progressBar, true);
 							slider._onRemainingBarClick({ pageY: bar.y - (bar.h >> 2), preventDefault: function(){}, stopPropagation: function(){} });
 							var v = slider.get('value').concat([]); // copy array
-							doh.is(slider.maximum-20, Math.round(v[0]), "max value " + v[0]);
+							doh.is(slider.maximum-20, Math.round(v[1]), "max value " + v[1]);
 							slider._onRemainingBarClick({ pageY: bar.y + bar.h + (bar.h >> 2), preventDefault: function(){}, stopPropagation: function(){} });
 							v = slider.get('value').concat([]); // copy array
-							doh.is(slider.minimum+20, Math.round(v[1]), "min value " + v[1]);
+							doh.is(slider.minimum+20, Math.round(v[0]), "min value " + v[0]);
 						},
 						function changeMax(){
 							var slider = registry.byId("hrSlider");
@@ -204,6 +218,24 @@
 	<label for="maxValue">Horizontal Slider Max Value:</label><input readonly id="maxValue" size="10" value="80.0%"/><br/>
 	<button id="disableButton" dojoType="dijit/form/Button" onClick="registry.byId('hrSlider').set('disabled', true);registry.byId('disableButton').set('disabled',true);registry.byId('enableButton').set('disabled',false);">Disable previous slider</button>
 	<button id="enableButton"  dojoType="dijit/form/Button" onClick="registry.byId('hrSlider').set('disabled', false);registry.byId('disableButton').set('disabled',false);registry.byId('enableButton').set('disabled', true);" disabled>Enable previous slider</button>
+
+	<h2>Horizontal slider RTL</h2>
+	<center>
+	<div 
+		id="hrSliderRtl" 
+		dir="rtl"
+		discreteValues="11"
+		onChange="horizRtlOnChange"
+		style="width:500px;" 
+		value="80,20" 
+		intermediateChanges="true"
+		dojoType="dojox/form/HorizontalRangeSlider">
+		<ol dojoType="dijit/form/HorizontalRuleLabels" container="topDecoration" style="height:1.2em;font-size:75%;color:gray;" count="7" constraints="{pattern:'#.00%'}"></ol>
+		<div dojoType="dijit/form/HorizontalRule" container="topDecoration" count=7 style="height:10px;margin-bottom:-5px;"></div>
+	</div>
+	</center>
+	<label for="minValueRtl">Horizontal Slider Min Value:</label><input readonly id="minValueRtl" size="10" value="20.0%"/><br/>
+	<label for="maxValueRtl">Horizontal Slider Max Value:</label><input readonly id="maxValueRtl" size="10" value="80.0%"/><br/>
 	
 	<h2>A customized horizontal slider</h2>
 	<div 


### PR DESCRIPTION
Keep the order of the value array consistent, even when in RTL mode so
that the order is always [min, max]. This also changes the order of the
values for VerticalRangeSlider to always be [min, max]. Fixes [#18430 ](https://bugs.dojotoolkit.org/ticket/18430).
