### PR TITLE
Fixes highlighting of triple-quoted Python string literals

### DIFF
--- a/highlight/languages/python.js
+++ b/highlight/languages/python.js
@@ -52,7 +52,37 @@ define(["../_base"], function(dh){
 			},
 			{
 				className: 'string',
+				begin: 'r\'\'\'', end: '\'\'\'',
+				relevance: 10
+			},
+			{
+				className: 'string',
+				begin: 'u\'\'\'', end: '(^|[^\\\\])\'\'\'',
+				relevance: 10
+			},
+			{
+				className: 'string',
+				begin: 'ur\'\'\'', end: '\'\'\'',
+				relevance: 10
+			},
+			{
+				className: 'string',
 				begin: '"""', end: '"""',
+				relevance: 10
+			},
+			{
+				className: 'string',
+				begin: 'r"""', end: '"""',
+				relevance: 10
+			},
+			{
+				className: 'string',
+				begin: 'u"""', end: '(^|[^\\\\])"""',
+				relevance: 10
+			},
+			{
+				className: 'string',
+				begin: 'ur"""', end: '"""',
 				relevance: 10
 			},
 			dhc.APOS_STRING_MODE,

--- a/highlight/tests/highlight.js
+++ b/highlight/tests/highlight.js
@@ -24,5 +24,71 @@ doh.register("dojox.highlight.tests.highlight", [
 		doh.assertEqual(unformatted, result.result);
 		doh.assertEqual(expected, result.partialResult);
 		doh.assertEqual("javascript", result.langName);
-	}
+	},
+  function test_validpython_raw3singlequotestring(){
+    // summary:
+    //    Test a valid Python raw triple single-quoted string literal
+    //    is highlighted correctly
+    var unformatted = "s = r'''value'''";
+    var expected = "s = <span class=\"string\">r'''value'''</span>";
+    var result = dojox.highlight.processString(unformatted, "python");
+		doh.assertEqual(expected, result.result);
+		doh.assertTrue(!result.partialResult);
+		doh.assertEqual("python", result.langName);
+  },
+  function test_validpython_3singlequoteunicode(){
+    // summary:
+    //    Test a valid Python triple single-quoted unicode literal
+    //    is highlighted correctly
+    var unformatted = "s = u'''value'''";
+    var expected = "s = <span class=\"string\">u'''value'''</span>";
+    var result = dojox.highlight.processString(unformatted, "python");
+		doh.assertEqual(expected, result.result);
+		doh.assertTrue(!result.partialResult);
+		doh.assertEqual("python", result.langName);
+  },
+  function test_validpython_raw3singlequoteunicode(){
+    // summary:
+    //    Test a valid Python raw triple single-quoted unicode literal
+    //    is highlighted correctly
+    var unformatted = "s = ur'''value'''";
+    var expected = "s = <span class=\"string\">ur'''value'''</span>";
+    var result = dojox.highlight.processString(unformatted, "python");
+		doh.assertEqual(expected, result.result);
+		doh.assertTrue(!result.partialResult);
+		doh.assertEqual("python", result.langName);
+  },
+  function test_validpython_raw3doublequotestring(){
+    // summary:
+    //    Test a valid Python raw triple double-quoted string literal
+    //    is highlighted correctly
+    var unformatted = 's = r"""value"""';
+    var expected = 's = <span class="string">r"""value"""</span>';
+    var result = dojox.highlight.processString(unformatted, "python");
+		doh.assertEqual(expected, result.result);
+		doh.assertTrue(!result.partialResult);
+		doh.assertEqual("python", result.langName);
+  },
+  function test_validpython_3doublequoteunicode(){
+    // summary:
+    //    Test a valid Python triple double-quoted unicode literal
+    //    is highlighted correctly
+    var unformatted = 's = u"""value"""';
+    var expected = 's = <span class="string">u"""value"""</span>';
+    var result = dojox.highlight.processString(unformatted, "python");
+		doh.assertEqual(expected, result.result);
+		doh.assertTrue(!result.partialResult);
+		doh.assertEqual("python", result.langName);
+  },
+  function test_validpython_raw3doublequoteunicode(){
+    // summary:
+    //    Test a valid Python raw triple double-quoted unicode literal
+    //    is highlighted correctly
+    var unformatted = 's = ur"""value"""';
+    var expected = 's = <span class="string">ur"""value"""</span>';
+    var result = dojox.highlight.processString(unformatted, "python");
+		doh.assertEqual(expected, result.result);
+		doh.assertTrue(!result.partialResult);
+		doh.assertEqual("python", result.langName);
+  }
 	]);

--- a/highlight/tests/highlightRequires.js
+++ b/highlight/tests/highlightRequires.js
@@ -5,3 +5,4 @@ dojo.require("dojox.highlight.languages.xml");
 dojo.require("dojox.highlight.languages.pygments.xml");
 dojo.require("dojox.highlight.languages.java");
 dojo.require("dojox.highlight.languages.xquery");
+dojo.require("dojox.highlight.languages.python");


### PR DESCRIPTION
This is a fix for https://bugs.dojotoolkit.org/ticket/16321. I submitted a patch and my Individual CLA two years ago, but the defect never got resolved.

This fix is important for Python highlighting because the string literal syntaxes that I've correct are idiomatic Python. Please refer to the Python style guide (https://www.python.org/dev/peps/pep-0008/#documentation-strings), as well as the documentation for the standard doctest module (https://docs.python.org/3/library/doctest.html#module-doctest).

Thanks