### PR TITLE
Fix for issue #18539 The Polish Pagination format is not acceptable for ...

### DIFF
--- a/grid/enhanced/nls/pl/Pagination.js
+++ b/grid/enhanced/nls/pl/Pagination.js
@@ -1,6 +1,6 @@
 define(
 ({
-	"descTemplate": "Od ${2} do ${3} z ${1} ${0}",
+	"descTemplate": "${2} - ${3} / ${1}",
 	"firstTip": "Pierwsza strona",
 	"lastTip": "Ostatnia strona",
 	"nextTip": "Następna strona",


### PR DESCRIPTION
...dojox grid. Polish has multiple words for items depending upon the number, so do not show the word.