### PR TITLE
#18533 dojox/lang/functional zip.js and curry.js in AMD style (broken in 1.10.4)

### DIFF
--- a/lang/functional/curry.js
+++ b/lang/functional/curry.js
@@ -1,6 +1,5 @@
-dojo.provide("dojox.lang.functional.curry");
-
-dojo.require("dojox.lang.functional.lambda");
+define(["dojo/_base/lang", "./lambda"],
+	function(lang, df){
 
 // This module adds high-level functions and related constructs:
 //	- currying and partial functions
@@ -13,10 +12,7 @@ dojo.require("dojox.lang.functional.lambda");
 
 // Defined methods:
 //	- take any valid lambda argument as the functional argument
-
-(function(){
-	var df = dojox.lang.functional, ap = Array.prototype;
-
+        var ap = Array.prototype;
 	var currying = function(/*Object*/ info){
 		return function(){	// Function
 			var args = info.args.concat(ap.slice.call(arguments, 0));
@@ -27,7 +23,7 @@ dojo.require("dojox.lang.functional.lambda");
 		};
 	};
 
-	dojo.mixin(df, {
+	lang.mixin(df, {
 		// currying and partial functions
 		curry: function(/*Function|String|Array*/ f, /*Number?*/ arity){
 			// summary:
@@ -95,4 +91,4 @@ dojo.require("dojox.lang.functional.lambda");
 			};
 		}
 	});
-})();
+});

--- a/lang/functional/zip.js
+++ b/lang/functional/zip.js
@@ -1,4 +1,5 @@
-dojo.provide("dojox.lang.functional.zip");
+define(["dojo/_base/lang", "./lambda"],
+	function(lang, df){
 
 // This module adds high-level functions and related constructs:
 //	- zip combiners
@@ -6,10 +7,7 @@ dojo.provide("dojox.lang.functional.zip");
 // Defined methods:
 //	- operate on dense arrays
 
-(function(){
-	var df = dojox.lang.functional;
-
-	dojo.mixin(df, {
+	lang.mixin(df, {
 		// combiners
 		zip: function(){
 			// summary:
@@ -41,4 +39,4 @@ dojo.provide("dojox.lang.functional.zip");
 			return df.zip.apply(null, a);	// Array
 		}
 	});
-})();
+});


### PR DESCRIPTION
zip.js and curry.js broken after switch from 1.10.1 to 1.10.4 (ticket #18533)
bill assured that old style "dojo.provide()" is still supported, but F12 inspection in browser shows no such method on global dojo object.
The files have been fixed to load as AMD modules, in line with foldl.js in the same folder. 