### PR TITLE
#18570 Chart Indicator label positioning

### DIFF
--- a/charting/plot2d/Indicator.js
+++ b/charting/plot2d/Indicator.js
@@ -452,7 +452,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "./Cartesia
 					this.chart,
 					g,
 					x, y,
-					"middle",
+					this.opt.start ? "start":"end",
 					text, this.opt.font?this.opt.font:t.indicator.font, this.opt.fontColor?this.opt.fontColor:t.indicator.fontColor);
 			var b = getBoundingBox(label);
 			b.x-=2; b.y-=1; b.width+=4; b.height+=2; b.r = this.opt.radius?this.opt.radius:t.indicator.radius;


### PR DESCRIPTION
With default options, the label is clipped at the start or at the end, depending on positioning, unless offset is specified, in which case one has to manually calculate the offset; the labels still look bad because they are rendered aligned to the middle.
This patch makes the labels hug the left or the right margin respectively, and they auto-size nicely.