### PR TITLE
#18570 dojox/charting Indicator label positioning

### DIFF
--- a/charting/plot2d/Indicator.js
+++ b/charting/plot2d/Indicator.js
@@ -452,7 +452,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "./Cartesia
 					this.chart,
 					g,
 					x, y,
-					"middle",
+					this.opt.vertical? "middle" : (this.opt.start ? "start":"end"),
 					text, this.opt.font?this.opt.font:t.indicator.font, this.opt.fontColor?this.opt.fontColor:t.indicator.fontColor);
 			var b = getBoundingBox(label);
 			b.x-=2; b.y-=1; b.width+=4; b.height+=2; b.r = this.opt.radius?this.opt.radius:t.indicator.radius;

--- a/charting/plot2d/Indicator.js
+++ b/charting/plot2d/Indicator.js
@@ -454,7 +454,11 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "./Cartesia
 					x, y,
 					this.opt.vertical? "middle" : (this.opt.start ? "start":"end"),
 					text, this.opt.font?this.opt.font:t.indicator.font, this.opt.fontColor?this.opt.fontColor:t.indicator.fontColor);
-			var b = getBoundingBox(label);
+			var b = label.getBoundingBox();
+                        if(this.opt.vertical && !this.opt.start) {
+                            b.y += b.height/2;
+                            label.setShape({y: y+b.height/2});
+                        }
 			b.x-=2; b.y-=1; b.width+=4; b.height+=2; b.r = this.opt.radius?this.opt.radius:t.indicator.radius;
 			var sh = this.opt.shadow!=undefined?this.opt.shadow:t.indicator.shadow,
 				ls = this.opt.stroke!=undefined?this.opt.stroke:t.indicator.stroke,

--- a/charting/plot2d/Indicator.js
+++ b/charting/plot2d/Indicator.js
@@ -454,7 +454,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "./Cartesia
 					x, y,
 					this.opt.vertical? "middle" : (this.opt.start ? "start":"end"),
 					text, this.opt.font?this.opt.font:t.indicator.font, this.opt.fontColor?this.opt.fontColor:t.indicator.fontColor);
-			var b = label.getBoundingBox();
+			var b = getBoundingBox(label);
                         if(this.opt.vertical && !this.opt.start) {
                             b.y += b.height/2;
                             label.setShape({y: y+b.height/2});


### PR DESCRIPTION
At the moment the label is clipped at the start or at the end in horizontal indicator, depending on positioning, unless offset is specified, in which case one has to manually calculate the offset, and the labels still look rubbish because they are rendered aligned to the middle.
The above patch makes the horizontal labels hug the left or the right margin respectively, and they auto-size nicely.
Tested "vertical:false/true" and "start: false/true". Note that in "vertical:true, start:false" setting the labels are still clipped at the top (as before). Dunno how to fix this. There is an unused function "getTextBBox()" at the top of the file that perhaps was meant to offset the labels by half their vertical size.