### PR TITLE
E-mail validator doesn't allow e-mails with TLD longer than 8 characters

### DIFF
--- a/validate/regexp.js
+++ b/validate/regexp.js
@@ -106,7 +106,7 @@ dxregexp = dojox.validate.regexp = {
 		//TODO: support unicode hostnames?
 		// Domain name labels can not end with a dash.
 		var domainLabelRE = "(?:[\\da-zA-Z](?:[-\\da-zA-Z]{0,61}[\\da-zA-Z])?)";
-		var domainNameRE = "(?:[a-zA-Z](?:[-\\da-zA-Z]{0,6}[\\da-zA-Z])?)"; // restricted version to allow backwards compatibility with allowLocal, allowIP
+		var domainNameRE = "(?:[a-zA-Z](?:[-\\da-zA-Z]{0,61}[\\da-zA-Z])?)"; // restricted version to allow backwards compatibility with allowLocal, allowIP
 
 		// port number RE
 		var portRE = flags.allowPort ? "(\\:\\d+)?" : "";


### PR DESCRIPTION
Fixes #18626

DNS allows for a maximum of 63 characters for an individual label.
http://stackoverflow.com/questions/9238640/how-long-can-a-tld-possibly-be