### PR TITLE
refs #17486, DTL crash on null variable

### DIFF
--- a/dtl/_base.js
+++ b/dtl/_base.js
@@ -548,7 +548,7 @@ define([
 	},
 	{
 		render: function(context, buffer){
-			var str = this.contents.resolve(context);
+			var str = this.contents.resolve(context) || "";
 			if(!str.safe){
 				str = dd._base.escape("" + str);
 			}


### PR DESCRIPTION
This patch will allegedly fix https://bugs.dojotoolkit.org/ticket/17486 . I've not looked into the DTL tests yet to see how to reproduce this yet.