### PR TITLE
deviceTheme: fix theme mapping for Android 5 and 6, fixes #18672

### DIFF
--- a/mobile/deviceTheme.js
+++ b/mobile/deviceTheme.js
@@ -172,6 +172,16 @@
 				[]
 			],
 			[
+				"Android 5",
+				"holodark",
+				[]
+			],
+			[
+				"Android 6",
+				"holodark",
+				[]
+			],
+			[
 				"Android",
 				"android",
 				[]


### PR DESCRIPTION
dojox/mobile/deviceTheme relies on UA sniffing for mapping a particular theme to each platform. Since Android 5, it loads the old android theme instead of the newer "holodark" theme which should load for all Android 4+.
A typical UA under Android 6 (preview) is the following:
Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MPA44I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36