### PR TITLE
clean-up Toaster (#18491)

### DIFF
--- a/widget/Toaster.js
+++ b/widget/Toaster.js
@@ -81,7 +81,6 @@ define([
 			this.ownerDocument.body.appendChild(this.domNode);
 
 			if(this.messageTopic){
-				// TODO: wrap in a call to this.own
 				this.own(topic.subscribe(this.messageTopic, lang.hitch(this, "_handleMessage")));
 			}
 		},
@@ -177,12 +176,12 @@ define([
 						}));
 						this.own(this.fadeAnim);
 						this._setHideTimer(duration);
-						this.own(aspect.after(this, 'onSelect', lang.hitch(this, function(){
+						this.on('select', lang.hitch(this, function(){
 							this._cancelHideTimer();
 							//force clear sticky message
 							this._stickyMessage=false;
 							this.fadeAnim.play();
-						})));
+						}));
 
 						this.isVisible = true;
 					})

--- a/widget/Toaster.js
+++ b/widget/Toaster.js
@@ -78,11 +78,11 @@ define([
 			this.hide();
 
 			// place node as a child of body for positioning
-			this.domNode.ownerDocument.body.appendChild(this.domNode);
+			this.ownerDocument.body.appendChild(this.domNode);
 
 			if(this.messageTopic){
 				// TODO: wrap in a call to this.own
-				topic.subscribe(this.messageTopic, lang.hitch(this, "_handleMessage"));
+				this.own(topic.subscribe(this.messageTopic, lang.hitch(this, "_handleMessage")));
 			}
 		},
 
@@ -159,7 +159,6 @@ define([
 				}else{
 					throw new Error(this.id + ".positionDirection is invalid: " + pd);
 				}
-//				this.slideAnim = this.own(coreFx.slideTo({
 				this.slideAnim = coreFx.slideTo({
 					node: this.containerNode,
 					top: 0, left: 0,
@@ -168,25 +167,27 @@ define([
 						//we build the fadeAnim here so we dont have to duplicate it later
 						// can't do a fadeHide because we're fading the
 						// inner node rather than the clipping node
-						this.fadeAnim = /*this.own(*/baseFx.fadeOut({
+						this.fadeAnim = (baseFx.fadeOut({
 							node: this.containerNode,
 							duration: 1000,
 							onEnd: lang.hitch(this, function(){
 								this.isVisible = false;
 								this.hide();
 							})
-						})/*)*/;
+						}));
+						this.own(this.fadeAnim);
 						this._setHideTimer(duration);
-						/*this.own(*/aspect.after(this, 'onSelect', lang.hitch(this, function(){
+						this.own(aspect.after(this, 'onSelect', lang.hitch(this, function(){
 							this._cancelHideTimer();
 							//force clear sticky message
 							this._stickyMessage=false;
 							this.fadeAnim.play();
-						}))/*)*/;
+						})));
 
 						this.isVisible = true;
 					})
-				})/*)*/;
+				});
+				this.own(this.slideAnim);
 				this.slideAnim.play();
 			}
 		},
@@ -279,8 +280,9 @@ define([
 			this._placeClip();
 
 			if(!this._scrollConnected){
-//				this._scrollConnected = this.own(on(window, "scroll", lang.hitch(this, "_placeClip")));
-//				this._scrollConnected = on(window, "scroll", lang.hitch(this, "_placeClip"));
+
+				this._scrollConnected = aspect.after(window, "scroll", lang.hitch(this, "_placeClip"));
+				this.own(this._scrollConnected);
 			}
 		},
 

--- a/widget/tests/test_Toaster.html
+++ b/widget/tests/test_Toaster.html
@@ -23,13 +23,12 @@
 			"dojo/domReady!"
 		], function (parser, topic, on, dom, registry) {
 			parser.parse();
-			var toast = registry.byId("toast");
-			function showTestMessage(){
+			on(dom.byId("submitButton1"), "click",function () {
 				topic.publish("testMessageTopic",
 					"This is a message! It's kind of long to show message wrapping."
 				);
-			}
-			function showAnotherMessage(){
+			});
+			on(dom.byId("submitButton2"), "click", function () {
 				topic.publish("testMessageTopic",
 					{
 						message: "This is another message!",
@@ -37,16 +36,12 @@
 						duration: 500
 					}
 				);
-			}
-			function showYetAnotherMessage(){
+			});
+			on(dom.byId("submitButton3"), "click", function () {
 				topic.publish("testMessageTopic",
 					{ message: "This is yet another message!" }
 				);
-			}
-
-			on(dom.byId("submitButton1"), "click", showTestMessage);
-			on(dom.byId("submitButton2"), "click", showAnotherMessage);
-			on(dom.byId("submitButton3"), "click", showYetAnotherMessage);
+			});
 		});
 
 	</script>

--- a/widget/tests/test_Toaster.html
+++ b/widget/tests/test_Toaster.html
@@ -47,7 +47,6 @@
 			on(dom.byId("submitButton1"), "click", showTestMessage);
 			on(dom.byId("submitButton2"), "click", showAnotherMessage);
 			on(dom.byId("submitButton3"), "click", showYetAnotherMessage);
-
 		});
 
 	</script>

--- a/widget/tests/test_Toaster.html
+++ b/widget/tests/test_Toaster.html
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
-        "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE HTML>
 <html>
 <head>
 	<title>Toaster Widget Dojo Tests</title>
@@ -7,60 +6,67 @@
 		@import "../../../dojo/resources/dojo.css";
 		@import "../../../dijit/themes/tundra/tundra.css";
 		@import "../../../dijit/themes/dijit.css";
-		@import "../../../dijit/tests/css/dijitTests.css"; 
+		@import "../../../dijit/tests/css/dijitTests.css";
 		@import "../Toaster/Toaster.css";
 	</style>
 
-	<script type="text/javascript" src="../../../dojo/dojo.js" data-dojo-config="isDebug:true, parseOnLoad: true"></script>
-	<script type="text/javascript">
-		dojo.require("dojox.widget.Toaster");
-		dojo.require("dojo.parser");	// scan page for widgets and instantiate them
+	<script src="../../../dojo/dojo.js" data-dojo-config="isDebug:true, async: 1"></script>
+	<script>
+		require([
+			"dojo/parser",
+			"dojo/topic",
+			"dojo/on",
+			"dojo/dom",
+			"dijit/registry",
+			"dijit/Tooltip",
+			"dojox/widget/Toaster",
+			"dojo/domReady!"
+		], function (parser, topic, on, dom, registry) {
+			parser.parse();
+			var toast = registry.byId("toast");
+			function showTestMessage(){
+				topic.publish("testMessageTopic",
+					"This is a message! It's kind of long to show message wrapping."
+				);
+			}
+			function showAnotherMessage(){
+				topic.publish("testMessageTopic",
+					{
+						message: "This is another message!",
+						type: "warning",
+						duration: 500
+					}
+				);
+			}
+			function showYetAnotherMessage(){
+				topic.publish("testMessageTopic",
+					{ message: "This is yet another message!" }
+				);
+			}
 
-		dojo.require("dijit.Tooltip");
-		
-		var toast = null;
-		function showTestMessage(){
-			dojo.publish("testMessageTopic", 
-				[ "This is a message! It's kind of long to show message wrapping."]
-			);
-		}
-		function showAnotherMessage(){
-			dojo.publish("testMessageTopic", 
-				[{
-					message: "This is another message!", 
-					type: "warning", 
-					duration: 500
-				}]
-			);
-		}
-		function showYetAnotherMessage(){
-			dojo.publish("testMessageTopic", 
-				[{ message: "This is yet another message!" }]
-			);
-		}
+			on(dom.byId("submitButton1"), "click", showTestMessage);
+			on(dom.byId("submitButton2"), "click", showAnotherMessage);
+			on(dom.byId("submitButton3"), "click", showYetAnotherMessage);
 
-		dojo.addOnLoad(function(){
-			toast = dijit.byId("toast");
 		});
+
 	</script>
 </head>
 <body class="tundra">
-	<div dojoType="dojox.widget.Toaster" id="toast" 
-		positionDirection="br-left" duration="0" 
-		messageTopic="testMessageTopic"></div>
+	<div data-dojo-type="dojox/widget/Toaster" id="toast"
+		data-dojo-props="positionDirection: 'br-left', duration:0, messageTopic:'testMessageTopic'"></div>
 
-	<div dojoType="dojox.widget.Toaster" id="toast2" 
-		separator="&lt;hr&gt;" positionDirection="bl-up" 
-		messageTopic="testMessageTopic"></div>
+	<div data-dojo-type="dojox/widget/Toaster" id="toast2"
+		data-dojo-props="separator: '&lt;hr&gt;', positionDirection: 'bl-up', messageTopic:'testMessageTopic'"></div>
 
-	<button type="submit" 
-		onclick="showTestMessage();">Click to show message</button>
-	<button type="submit" 
-		onclick="showAnotherMessage();">Click to show another message</button>
-	<button type="submit" 
-		onclick="showYetAnotherMessage();">Click to show yet another message</button>
+	<button type="submit" id="submitButton1"
+		>Click to show message</button>
+	<button type="submit" id="submitButton2"
+		>Click to show another message</button>
+	<button type="submit" id="submitButton3"
+		>Click to show yet another message</button>
 
-	<h1>dojox.widget.Toaster test</h1>
+	<h1>dojox/widget/Toaster test</h1>
 
 	<div style="color: #FF0000;">
 		When you click any of the buttons above, the bottom right hand message will
@@ -69,17 +75,17 @@
 		displayed in the bottom right corner it should append the new message below
 		the old one with a separator between them.
 	</div>
-	
+
 	<h2>A Tooltip: (#10046)</h2>
 	<div><span id="one" class="tt" tabindex="0"> focusable text </span>
-		<span dojoType="dijit.Tooltip" connectId="one" id="one_tooltip">
+		<span data-dojo-type="dijit/Tooltip" data-dojo-props="connectId:'one'" id="one_tooltip">
 			<b>
 				<span style="color: blue;">rich formatting</span>
 				<span style="color: red; font-size: x-large;"><i>!</i></span>
 			</b>
 		</span>
 	</div>
-	
+
 	<p>
 		Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean semper
 		sagittis velit. Cras in mi. Duis porta mauris ut ligula. Proin porta rutrum
@@ -156,6 +162,6 @@
 		sapien. Suspendisse imperdiet. Class aptent taciti sociosqu ad litora
 		torquent per conubia nostra, per inceptos hymenaeos.
 	</p>
-		
+
 </body>
 </html>


### PR DESCRIPTION
This is not complete, it started as an attempt to wrap a topic call in a this.own statement.

Toaster does not appear to implement Destroyable or Evented, so a few things are not working as expected. This patch does a fairly significant best practices clean-up to the widget and test case, but still needs to extend those interfaces to work as expected.

Perhaps @wkeese could take a quick look?