### PR TITLE
Fix Reflected XSS

### DIFF
--- a/analytics/logger/dojoxAnalytics.php
+++ b/analytics/logger/dojoxAnalytics.php
@@ -21,7 +21,7 @@
 	
 	fclose($handle);
 
-	$response = '{"eventsReceived": "' . sizeof($items) . '", "id": "' . $id . '"}';
+	$response = '{"eventsReceived": "' . sizeof($items) . '", "id": "' . htmlentities($id) . '"}';
 	if ($_REQUEST["callback"]){
 		print htmlentities($_REQUEST["callback"]) . "(" . $response . ");";
 	}else{


### PR DESCRIPTION
If ./logs/analytics.log exists and you call this script with ?id=[XSS PAYLOAD] you can manage to have a Reflected XSS.

htmlentities should be enough to prevent it.