### PR TITLE
fix PointerEvent support in Edge, fixes #18735

### DIFF
--- a/mobile/Slider.js
+++ b/mobile/Slider.js
@@ -12,9 +12,10 @@ define([
 	"dojo/keys",
 	"dojo/touch",
 	"dijit/_WidgetBase",
-	"dijit/form/_FormValueMixin"
+	"dijit/form/_FormValueMixin",
+	"./common"
 ],
-	function(array, connect, declare, lang, win, has, domClass, domConstruct, domGeometry, domStyle, keys, touch, WidgetBase, FormValueMixin){
+	function(array, connect, declare, lang, win, has, domClass, domConstruct, domGeometry, domStyle, keys, touch, WidgetBase, FormValueMixin, common){
 
 	return declare("dojox.mobile.Slider", [WidgetBase, FormValueMixin], {
 		// summary:
@@ -72,9 +73,7 @@ define([
 			}
 			this.inherited(arguments);
 			// prevent browser scrolling on IE10 (evt.preventDefault() is not enough)
-			if(typeof this.domNode.style.msTouchAction != "undefined"){
-				this.domNode.style.msTouchAction = "none";
-			}
+			common.setTouchAction(this.domNode, "none");
 		},
 
 		_setMinAttr: function(/*Number*/ min){

--- a/mobile/Switch.js
+++ b/mobile/Switch.js
@@ -70,9 +70,7 @@ define([
 					this.srcNodeRef : domConstruct.create("span");
 			}
 			// prevent browser scrolling on IE10 (evt.preventDefault() is not enough)
-			if(typeof this.domNode.style.msTouchAction != "undefined"){
-				this.domNode.style.msTouchAction = "none";
-			}
+			dm.setTouchAction(this.domNode, "none");
 			this.inherited(arguments);
 			if(!this.templateString){ // true if this widget is not templated
 				var c = (this.srcNodeRef && this.srcNodeRef.className) || this.className || this["class"];

--- a/mobile/_EditableListMixin.js
+++ b/mobile/_EditableListMixin.js
@@ -12,8 +12,9 @@ define([
 	"dojo/touch",
 	"dojo/dom-attr",
 	"dijit/registry",
-	"./ListItem"
-], function(array, connect, declare, event, win, domClass, domGeometry, domStyle, touch, domAttr, registry, ListItem){
+	"./ListItem",
+	"./common"
+], function(array, connect, declare, event, win, domClass, domGeometry, domStyle, touch, domAttr, registry, ListItem, common){
 
 	// module:
 	//		dojox/mobile/EditableRoundRectList
@@ -196,9 +197,7 @@ define([
 				}
 				child.rightIconNode.style.display = "";
 				child.deleteIconNode.style.display = "";
-				if(typeof child.rightIconNode.style.msTouchAction != "undefined"){
-					child.rightIconNode.style.msTouchAction = "none";
-				}
+				common.setTouchAction(child.rightIconNode, "none");
 			}, this);
 			if(!this._handles){
 				this._handles = [
@@ -218,9 +217,7 @@ define([
 			array.forEach(this.getChildren(), function(child){
 				child.rightIconNode.style.display = "none";
 				child.deleteIconNode.style.display = "none";
-				if(typeof child.rightIconNode.style.msTouchAction != "undefined"){
-					child.rightIconNode.style.msTouchAction = "auto";
-				}
+				common.setTouchAction(child.rightIconNode, "auto");
 			});
 			if(this._handles){
 				array.forEach(this._handles, this.disconnect, this);

--- a/mobile/common.js
+++ b/mobile/common.js
@@ -327,6 +327,11 @@ define([
 		}
 	};
 
+	var touchActionProp = has("pointer-events") ? "touchAction" : has("MSPointer") ? "msTouchAction" : null;
+	dm.setTouchAction = touchActionProp ? function(/*Node*/node, /*Boolean*/value){
+		node.style[touchActionProp] = value;
+	} : function(){};
+
 	// Set the background style using dojo/domReady, not dojo/ready, to ensure it is already
 	// set at widget initialization time. (#17418) 
 	domReady(function(){

--- a/mobile/scrollable.js
+++ b/mobile/scrollable.js
@@ -14,10 +14,11 @@ define([
 	"./sniff",
 	"./_css3",
 	"./_maskUtils",
+	"./common",
 	"dojo/_base/declare",
 	"dojo/has!dojo-bidi?dojox/mobile/bidi/Scrollable"
 ], function(dojo, connect, event, lang, win, domClass, domConstruct, domStyle,
-			 domGeom, touch, registry, TextBoxMixin, has, css3, maskUtils, declare, BidiScrollable){
+			 domGeom, touch, registry, TextBoxMixin, has, css3, maskUtils, common, declare, BidiScrollable){
 
 	// module:
 	//		dojox/mobile/scrollable
@@ -152,9 +153,7 @@ define([
 				}
 			}
 			// prevent browser scrolling on IE10 (evt.preventDefault() is not enough)
-			if(typeof this.domNode.style.msTouchAction != "undefined"){
-				this.domNode.style.msTouchAction = "none";
-			}
+			common.setTouchAction(this.domNode, "none");
 			this.touchNode = this.touchNode || this.containerNode;
 			this._v = (this.scrollDir.indexOf("v") != -1); // vertical scrolling
 			this._h = (this.scrollDir.indexOf("h") != -1); // horizontal scrolling


### PR DESCRIPTION
Issue: https://bugs.dojotoolkit.org/ticket/18735

The PR
-refactors the touchAction css property handling into one single location (in dojox/mobile/common.js)
-fixes MS Edge support by adding prefix-less ```touch-action``` css property support (complies to PointerEvents spec)