### PR TITLE
fixes #18495, Toaster duration check

### DIFF
--- a/widget/Toaster.js
+++ b/widget/Toaster.js
@@ -103,7 +103,7 @@ define([
 			// duration:
 			//		duration in milliseconds to display message before removing it. Widget has default value.
 
-			duration = duration||this.duration;
+			duration = (duration === undefined) ? this.duration : duration;
 			// sync animations so there are no ghosted fades and such
 			if(this.slideAnim){
 				if(this.slideAnim.status() != "playing"){


### PR DESCRIPTION
Allows setting a duration of 0, without it resetting to the default of 2000ms.