### PR TITLE
fixes #18196, Standby widget breaking in IE9-11

### DIFF
--- a/widget/Standby.js
+++ b/widget/Standby.js
@@ -210,16 +210,25 @@ return declare("dojox.widget.Standby", [_Widget, _TemplatedMixin],{
 		// summary:
 		//		Function to hide the blocking overlay and status icon or text.
 		if(this._displayed){
-			if(this._anim){
-				this._anim.stop();
-				delete this._anim;
-			}
-			this._size();
-			this._fadeOut();
-			this._displayed = false;
-			if(this._resizeCheck !== null){
-				clearInterval(this._resizeCheck);
-				this._resizeCheck = null;
+			// Ideally would come up with something better than try/catch,
+			// but don't see another simple workaround for
+			// https://bugs.dojotoolkit.org/ticket/18196 and
+			// https://bugs.dojotoolkit.org/ticket/14984
+			try{
+				if(this._anim){
+					this._anim.stop();
+					delete this._anim;
+				}
+				this._size();
+			}catch(e){
+				console.error(e);
+			}finally{
+				this._fadeOut();
+				this._displayed = false;
+				if(this._resizeCheck !== null){
+					clearInterval(this._resizeCheck);
+					this._resizeCheck = null;
+				}
 			}
 		}
 	},


### PR DESCRIPTION
I'm not a fan of wrapping something in a try/catch, but I don't see an easy alternative here, and it's a rarely used dojox widget, so at this point I'd rather unbreak people than refactor the widget. A patch is welcome to make this better. This also fixes #14984.