### PR TITLE
Hitch the formatCell function so that this resolved correctly within …

### DIFF
--- a/grid/enhanced/plugins/exporter/CSVWriter.js
+++ b/grid/enhanced/plugins/exporter/CSVWriter.js
@@ -1,9 +1,10 @@
 define([
 	"dojo/_base/declare",
+	"dojo/_base/lang",
 	"dojo/_base/array",
 	"./_ExportWriter",
 	"../Exporter"
-], function(declare, array, _ExportWriter, Exporter){
+], function(declare, lang, array, _ExportWriter, Exporter){
 
 Exporter.registerWriter("csv", "dojox.grid.enhanced.plugins.exporter.CSVWriter");
 
@@ -52,7 +53,7 @@ return declare("dojox.grid.enhanced.plugins.exporter.CSVWriter", _ExportWriter, 
 		// summary:
 		//		Overrided from _ExportWriter
 		var row = [],
-			func = this._formatCSVCell;
+			func = lang.hitch(this, this._formatCSVCell);
 		array.forEach(arg_obj.grid.layout.cells, function(cell){
 			//We are not interested in indirect selectors and row indexes.
 			if(!cell.hidden && array.indexOf(arg_obj.spCols,cell.index) < 0){


### PR DESCRIPTION
This is a simple fix to the CSVWriter.js so that the scope is not lost when passing the formatCell function into a loop array as a variable.   Without it, the , is never escaped in data and thus breaks the CSV output.