### PR TITLE
change 'isArray' to 'isArrayLike' in dojox/grid/_Layout::setStructure

### DIFF
--- a/grid/_Layout.js
+++ b/grid/_Layout.js
@@ -74,7 +74,7 @@ return declare("dojox.grid._Layout", null, {
 				}
 			}
 		}
-		
+
 		//Fix #9481 - reset idx in cell markup
 		array.forEach(this.cells, function(c){
 			var marks = c.markup[2].split(" ");
@@ -84,7 +84,7 @@ return declare("dojox.grid._Layout", null, {
 				c.markup[2] = marks.join(" ");
 			}
 		});
-		
+
 		this.grid.setupHeaderMenu();
 		//this.grid.renderOnIdle();
 	},
@@ -103,7 +103,7 @@ return declare("dojox.grid._Layout", null, {
 			return false;
 		}
 	},
-	
+
 	addCellDef: function(inRowIndex, inCellIndex, inDef){
 		var self = this;
 		var getCellWidth = function(inDef){
@@ -142,7 +142,7 @@ return declare("dojox.grid._Layout", null, {
 		props.unitWidth = getCellWidth(inDef);
 		return new cell_type(lang.mixin({}, this._defaultCellProps, inDef, props));
 	},
-	
+
 	addRowDef: function(inRowIndex, inDef){
 		var result = [];
 		var relSum = 0, pctSum = 0, doRel = true;
@@ -174,7 +174,7 @@ return declare("dojox.grid._Layout", null, {
 			});
 		}
 		return result;
-	
+
 	},
 
 	addRowsDef: function(inDef){
@@ -190,7 +190,7 @@ return declare("dojox.grid._Layout", null, {
 		}
 		return result;
 	},
-	
+
 	addViewDef: function(inDef){
 		this._defaultCellProps = inDef.defaultCell || {};
 		if(inDef.width && inDef.width == "auto"){
@@ -198,7 +198,7 @@ return declare("dojox.grid._Layout", null, {
 		}
 		return lang.mixin({}, inDef, {cells: this.addRowsDef(inDef.rows || inDef.cells)});
 	},
-	
+
 	setStructure: function(inStructure){
 		this.fieldIndex = 0;
 		this.cells = [];
@@ -244,7 +244,7 @@ return declare("dojox.grid._Layout", null, {
 					("cells" in def || "rows" in def || ("type" in def && !isCell(def))));
 		};
 
-		if(lang.isArray(inStructure)){
+		if(lang.isArrayLike(inStructure)){
 			var hasViews = false;
 			for(var i=0, st; (st=inStructure[i]); i++){
 				if(isView(st)){


### PR DESCRIPTION
Change [4c89d551d73649aac52c8ce3cb7e6edba1dcc4d9](https://github.com/dojo/dojo/commit/4c89d551d73649aac52c8ce3cb7e6edba1dcc4d9) in Dojo altered the way that dojo/_base/lang::isArray and ::isArrayLike are defined. This introduced a regression in dojox/grid/_Layout which caused grid layout's to be ignored when a DataGrid was defined via HTML Markup. This change switches isArray to isArrayLike in the setStructure method to allow it to process the NodeList that is returned when the column definitions are defined in declaratively.

Note: this functionality is covered by dojox/grid/tests/test_markup.html which was not working prior to this change.