### PR TITLE
Fixes #18883 StatefulArray.watchElements now have consistent arguments: adds and r…

### DIFF
--- a/mvc/StatefulArray.js
+++ b/mvc/StatefulArray.js
@@ -10,7 +10,7 @@ define([
 
 		// Notify change of elements.
 		if(a._watchElementCallbacks){
-			a._watchElementCallbacks();
+			a._watchElementCallbacks(undefined, [], []);
 		}
 
 		return a; // dojox/mvc/StatefulArray


### PR DESCRIPTION
Hello! It's my first contributing experience, so if i do something wrong - please tell me.
I can register bug in bugzilla and discuss it.

The problem description:
StatefulArray has watchElements method, that method call callback with arguments
**index**, **removals** and **adds**.

When you add element or remove element from array, then **removals** and adds **adds** is array.

But if you sort array, then **removals** and **adds** has value undefined.

It's looks like inconsistent API, we get Exception in our project because of that.