### PR TITLE
Fixes #18883 StatefulArray.watchElements now have consistent argument…

### DIFF
--- a/mvc/StatefulArray.js
+++ b/mvc/StatefulArray.js
@@ -10,7 +10,7 @@ define([
 
 		// Notify change of elements.
 		if(a._watchElementCallbacks){
-			a._watchElementCallbacks();
+			a._watchElementCallbacks(undefined, [], []);
 		}
 
 		return a; // dojox/mvc/StatefulArray


### PR DESCRIPTION
@vansimke, @dylans here is pull request to master.

Origin pull request: https://github.com/dojo/dojox/pull/240

The problem description:
StatefulArray has watchElements method, that method call callback with arguments
index, removals and adds.

When you add element or remove element from array, then removals and adds adds is array.

But if you sort array, then removals and adds has value undefined.

It's looks like inconsistent API, we get Exception in our project because of that.

Link for bug discuss:
https://bugs.dojotoolkit.org/ticket/18883