### PR TITLE
fixes #18865, regression in dojox/dtl rendering

### DIFF
--- a/dtl/tag/logic.js
+++ b/dtl/tag/logic.js
@@ -161,18 +161,21 @@ define([
 				forloop.first = !j;
 				forloop.last = (j == arred.length - 1);
 
-				if(assign.length > 1 && lang.isArrayLike(item)){
-					if(!dirty){
-						dirty = true;
-						context = context.push();
+				if (lang.isArrayLike(item)) {
+					if(assign.length > 1){
+						if(!dirty){
+							dirty = true;
+							context = context.push();
+						}
+						var zipped = {};
+						for(k = 0; k < item.length && k < assign.length; k++){
+							zipped[assign[k]] = item[k];
+						}
+						lang.mixin(context, zipped);
+					}else{
+						// in single assignment scenarios, pick only the value
+						context[assign[0]] = item[1];
 					}
-					var zipped = {};
-					for(k = 0; k < item.length && k < assign.length; k++){
-						zipped[assign[k]] = item[k];
-					}
-					lang.mixin(context, zipped);
-				}else{
-					context[assign[0]] = item;
 				}
 
 				if(j + 1 > this.pool.length){


### PR DESCRIPTION
This PR is intended to allow for loops to work correctly when looping over objects. Prior to https://github.com/dojo/dojox/commit/1dcf38ea5f15079355ac20df0b372753da9dd6bc, using a `{% for item in items %}` construct would render the values properly when items was an object (i.e. it would render the values of the object, not the keys). Commit https://github.com/dojo/dojox/commit/1dcf38ea5f15079355ac20df0b372753da9dd6bc was made to support rendering keys and values (e.g. {% for k, v in items %}), but broke the original functionality since the entire object entry is now rendered (i.e. the key and the value together). 

The proposed change inspects the number of assignments that are requested when an object is provided as the context. If one is requested, then `object[key]` is provided instead of the entire entry. The behavior in the event that the key and the value are requested is the same as that provided by  https://github.com/dojo/dojox/commit/1dcf38ea5f15079355ac20df0b372753da9dd6bc.