### PR TITLE
Fix Dojo build, v1.12-rc3

### DIFF
--- a/mvc/_atBindingMixin.js
+++ b/mvc/_atBindingMixin.js
@@ -7,14 +7,12 @@ define([
 	"./resolve",
 	"./sync"
 ], function(array, lang, declare, has, Stateful, resolve, sync){
-	if(has("mvc-bindings-log-api")){
-		function getLogContent(/*dojo/Stateful*/ target, /*String*/ targetProp){
-			return [target._setIdAttr || !target.declaredClass ? target : target.declaredClass, targetProp].join(":");
-		}
+	function getLogContent(/*dojo/Stateful*/ target, /*String*/ targetProp){
+		return [target._setIdAttr || !target.declaredClass ? target : target.declaredClass, targetProp].join(":");
+	}
 
-		function logResolveFailure(target, targetProp){
-			console.warn(targetProp + " could not be resolved" + (typeof target == "string" ? (" with " + target) : "") + ".");
-		}
+	function logResolveFailure(target, targetProp){
+		console.warn(targetProp + " could not be resolved" + (typeof target == "string" ? (" with " + target) : "") + ".");
 	}
 
 	function getParent(/*dijit/_WidgetBase*/ w){

--- a/mvc/sync.js
+++ b/mvc/sync.js
@@ -56,13 +56,11 @@ define([
 
 	var sync;
 
-	if(has("mvc-bindings-log-api")){
-		function getLogContent(/*dojo/Stateful*/ source, /*String*/ sourceProp, /*dojo/Stateful*/ target, /*String*/ targetProp){
-			return [
-				[target.canConvertToLoggable || !target.declaredClass ? target : target.declaredClass, targetProp].join(":"),
-				[source.canConvertToLoggable || !source.declaredClass ? source : source.declaredClass, sourceProp].join(":")
-			];
-		}
+	function getLogContent(/*dojo/Stateful*/ source, /*String*/ sourceProp, /*dojo/Stateful*/ target, /*String*/ targetProp){
+		return [
+			[target.canConvertToLoggable || !target.declaredClass ? target : target.declaredClass, targetProp].join(":"),
+			[source.canConvertToLoggable || !source.declaredClass ? source : source.declaredClass, sourceProp].join(":")
+		];
 	}
 
 	function equals(/*Anything*/ dst, /*Anything*/ src){


### PR DESCRIPTION
Dojo build, v1.12-rc3 fails with the following errors:

```
_atBindingMixin.js.uncompressed.js:70:` ERROR - Ambiguous use of a named function: logResolveFailure.
			if(has("mvc-bindings-log-api") && (!resolvedSource || /^rel:/.test(source) && !parent)){ logResolveFailure(source, sourceProp); }
			                                                                                         ^

_atBindingMixin.js.uncompressed.js:71: ERROR - Ambiguous use of a named function: logResolveFailure.
			if(has("mvc-bindings-log-api") && (!resolvedTarget || /^rel:/.test(target) && !parent)){ logResolveFailure(target, targetProp); }
			                                                                                         ^

_atBindingMixin.js.uncompressed.js:74: ERROR - Ambiguous use of a named function: logResolveFailure.
				if(has("mvc-bindings-log-api")){ logResolveFailure(source, sourceProp); }
				                                 ^

_atBindingMixin.js.uncompressed.js:84: ERROR - Ambiguous use of a named function: getLogContent.
					 0 && console.log("dojox/mvc/_atBindingMixin set " + resolvedSource + " to: " + getLogContent(resolvedTarget, targetProp));
					                                                                                ^

4 error(s), 0 warning(s)

sync.js.uncompressed.js:115: ERROR - Ambiguous use of a named function: getLogContent.
			var logContent = getLogContent(source, prop, target, targetProp);
			                 ^

sync.js.uncompressed.js:182: ERROR - Ambiguous use of a named function: getLogContent.
			var logContent = getLogContent(source, sourceProp, target, targetProp);
			                 ^

2 error(s), 0 warning(s)
```