### PR TITLE
Add selectAll method to dojox/form/CheckedMultiSelect

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,8 @@
 		"url": "https://github.com/dojo/dojox.git"
 	},
 	"dependencies": {
-		"dojo": "1.12.1",
-		"dijit": "1.12.1"
+		"dojo": "1.12.2-pre",
+		"dijit": "1.12.2-pre"
 	},
 	"devDependencies": {
 	}

--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,8 @@
 		"url": "https://github.com/dojo/dojox.git"
 	},
 	"dependencies": {
-		"dojo": "1.13.0-pre",
-		"dijit": "1.13.0-pre"
+		"dojo": "1.12.1",
+		"dijit": "1.12.1"
 	},
 	"devDependencies": {
 	}

--- a/dtl/_base.js
+++ b/dtl/_base.js
@@ -548,7 +548,10 @@ define([
 	},
 	{
 		render: function(context, buffer){
-			var str = this.contents.resolve(context) || "";
+			var str = this.contents.resolve(context);
+			if (str === undefined || str === null) {
+				str = '';
+			}
 			if(!str.safe){
 				str = dd._base.escape("" + str);
 			}

--- a/form/_BusyButtonMixin.js
+++ b/form/_BusyButtonMixin.js
@@ -2,13 +2,14 @@ define([
 	"dojo/_base/lang",
 	"dojo/dom-attr",
 	"dojo/dom-class",
+        "dojo/dom-construct",
 	"dijit/form/Button",
 	"dijit/form/DropDownButton",
 	"dijit/form/ComboButton",
 	"dojo/i18n",
 	"dojo/i18n!dijit/nls/loading",
 	"dojo/_base/declare"
-], function(lang, domAttr, domClass, Button, DropDownButton, ComboButton, i18n, nlsLoading, declare){
+], function(lang, domAttr, domClass, domConstruct, Button, DropDownButton, ComboButton, i18n, nlsLoading, declare){
 return declare("dojox.form._BusyButtonMixin", null, {
 
 	// isBusy: Boolean

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "dojox",
-	"version": "1.12.1",
+	"version": "1.12.2-pre",
 	"directories": {
 		"lib": "."
 	},
 	"main": "main",
 	"dependencies": {
-		"dojo": "1.12.1",
-		"dijit": "1.12.1"
+		"dojo": "1.12.2-pre",
+		"dijit": "1.12.2-pre"
 	},
 	"description": "Dojo eXtensions, a rollup of many useful sub-projects and varying states of maturity – from very stable and robust, to alpha and experimental. See individual projects contain README files for details.",
 	"license" : "BSD-3-Clause OR AFL-2.1",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "dojox",
-	"version": "1.13.0-pre",
+	"version": "1.12.1",
 	"directories": {
 		"lib": "."
 	},
 	"main": "main",
 	"dependencies": {
-		"dojo": "1.13.0-pre",
-		"dijit": "1.13.0-pre"
+		"dojo": "1.12.1",
+		"dijit": "1.12.1"
 	},
 	"description": "Dojo eXtensions, a rollup of many useful sub-projects and varying states of maturity – from very stable and robust, to alpha and experimental. See individual projects contain README files for details.",
 	"license" : "BSD-3-Clause OR AFL-2.1",


### PR DESCRIPTION
I extended the dojox.form.CheckedMultiSelect and create a select all method. Hoped that someone can put it into the offical release. 

```
define(["dojo/_base/declare", "dojox/form/CheckedMultiSelect","dojo/_base/array"],
function(declare, CheckedMultiSelect, array) {
	return declare("CheckedMultiSelect", [CheckedMultiSelect], {
		selectAllSelection: function(onChange){
			// copy from invertSelection()
			if(this.multiple){
				array.forEach(this.options, function(i){
					i.selected = true;
				});
				this._updateSelection();
			}
		}
    });
});
```