### PR TITLE
1.12 error rendering templates, fixes https://bugs.dojotoolkit.org/ticket/18952

### DIFF
--- a/dtl/_base.js
+++ b/dtl/_base.js
@@ -548,7 +548,10 @@ define([
 	},
 	{
 		render: function(context, buffer){
-			var str = this.contents.resolve(context) || "";
+			var str = this.contents.resolve(context);
+            if (str === undefined || str === null) {
+                str = '';
+            }
 			if(!str.safe){
 				str = dd._base.escape("" + str);
 			}

--- a/dtl/_base.js
+++ b/dtl/_base.js
@@ -549,9 +549,9 @@ define([
 	{
 		render: function(context, buffer){
 			var str = this.contents.resolve(context);
-            if (str === undefined || str === null) {
-                str = '';
-            }
+			if (str === undefined || str === null) {
+				str = '';
+			}
 			if(!str.safe){
 				str = dd._base.escape("" + str);
 			}


### PR DESCRIPTION
Found out that for some forms that i have that is being rendered with dojox/dtl, the first values in a group of values were sending as group[].attribute instead of group[0].attribute causing the backend to fail, this fixes that issue, this will now allow 0 to pass correctly