### PR TITLE
Fixes #15842: stop scroll on touch in desktop browsers

### DIFF
--- a/mobile/scrollable.js
+++ b/mobile/scrollable.js
@@ -1410,7 +1410,7 @@ define([
 			//		unexpectedly when the user flicks the screen to scroll.
 			//		Note that only the desktop browsers need the cover.
 
-			if(!has("touch") && !has("pointer-events") && !this.noCover){
+			if(!has("touch") && !(has("pointer-events") || has("MSPointer")) && !this.noCover){
 				if(!dm._cover){
 					dm._cover = domConstruct.create("div", null, win.doc.body);
 					dm._cover.className = "mblScrollableCover";

--- a/mobile/scrollable.js
+++ b/mobile/scrollable.js
@@ -1410,7 +1410,7 @@ define([
 			//		unexpectedly when the user flicks the screen to scroll.
 			//		Note that only the desktop browsers need the cover.
 
-			if(!has("touch") && !this.noCover){
+			if(!has("touch") && !has("pointer-events") && !this.noCover){
 				if(!dm._cover){
 					dm._cover = domConstruct.create("div", null, win.doc.body);
 					dm._cover.className = "mblScrollableCover";


### PR DESCRIPTION
Currently, the cover element is created for any non-touch-enabled
browser including browsers with pointer events. This patch disables the
creation of the cover element for browsers with pointer events.