### PR TITLE
Fix sporadic gesture/tap error

### DIFF
--- a/gesture/tap.js
+++ b/gesture/tap.js
@@ -129,6 +129,9 @@ var clz = declare(/*===== "dojox.gesture.tap", =====*/Base, {
 	_isTap: function(/*Object*/data, /*Event*/e){
 		// summary:
 		//		Check whether it's an valid tap
+		if (!data.context) {
+			return false;
+		}
 		var dx = Math.abs(data.context.x - e.screenX);
 		var dy = Math.abs(data.context.y - e.screenY);
 		return dx <= this.tapRadius && dy <= this.tapRadius;


### PR DESCRIPTION
This is a fix for https://bugs.dojotoolkit.org/ticket/17716. The root issue _appears_ to be that in some cases `release` isn't being called between presses. This means that multiple `tapTimeOut` timers are started, and any of them that fire after the first will throw an error.