### PR TITLE
charting/plot2d/Pie radius and label fixes

### DIFF
--- a/charting/plot2d/Pie.js
+++ b/charting/plot2d/Pie.js
@@ -242,7 +242,7 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare", "dojo/dom-g
 					this.renderLabel(s, circle.cx, circle.cy + size/3, this.opt.zeroDataMessage, {
 						series: {
 							font: taFont,
-							fontColor: taFontColor 
+							fontColor: taFontColor
 						}
 					},	null, "middle");
 				}
@@ -281,7 +281,7 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare", "dojo/dom-g
 				slices = df.map(filteredRun, "/this", df.foldl(filteredRun, "+", 0));
 				if(this.opt.labels){
 					labels = arr.map(slices, function(x, i){
-						if(x <= 0){ return ""; }
+						if(x < 0){ return ""; }
 						var v = run[i];
 						return v.hasOwnProperty("text") ? v.text : this._getLabel(x * 100) + "%";
 					}, this);
@@ -312,7 +312,7 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare", "dojo/dom-g
 				r = this.opt.radius < r * 0.9 ? this.opt.radius : r * 0.9;
 			}
 
-			if (this.opt.labels && this.opt.labelStyle == "columns") {
+			if (!this.opt.radius && this.opt.labels && this.opt.labelStyle == "columns") {
 				r = r / 2;
 				if (rx > ry && rx > r * 2) {
 					r *= rx / (r * 2);
@@ -593,7 +593,7 @@ define(["dojo/_base/lang", "dojo/_base/array" ,"dojo/_base/declare", "dojo/dom-g
 						if(i + 1 == slices.length){
 							end = startAngle + 2 * Math.PI;
 						}
-						if(this.minWidth === 0 ? end - start >= 0.001 : slice !== 0){
+						if(this.minWidth !== 0 || end - start >= 0.001){
 							// var labelAngle = (start + end) / 2;
 							var labelAngle = localStart + (slicesSteps[i].step / 2);//(start + end) / 2,
 							if(significantCount === 1 && !this.opt.minWidth){

--- a/charting/tests/test_pie2d.html
+++ b/charting/tests/test_pie2d.html
@@ -44,15 +44,29 @@
 				chart2.render();
 
 				var chart3 = new Chart("test3");
-				chart3.setTheme(pkGreen);
+				chart3.setTheme(pkBlue);
 				chart3.addPlot("default", {
-					type: Pie,
-					font: "normal normal bold 10pt Tahoma",
-					fontColor: "white",
-					labelOffset: 25,
-					radius: 90
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "black",
+					htmlLabels: true,
+					labelStyle: "columns",
+					labels: true,
+					precision: 0,
+					radius: 75,
+					startAngle: -10,
+					type: Pie
 				});
-				chart3.addSeries("Series A", [4, 2, 1, 1]);
+				chart3.addSeries("Series A", [
+					{ y: 52.39, text: "Chrome" },
+					{ y: 14.4, text: "Safari" },
+					{ y: 8.55, text: "UC Browser" },
+					{ y: 6.73, text: "Firefox" },
+					{ y: 4.37, text: "IE" },
+					{ y: 3.78, text: "Opera" },
+					{ y: 3.24, text: "Samsung" },
+					{ y: 1.77, text: "Edge" },
+					{ y: 0, text: "Other" }
+				]);
 				chart3.render();
 
 				var chart4 = new Chart("test4");
@@ -60,22 +74,34 @@
 				chart4.addPlot("default", {
 					type: Pie,
 					font: "normal normal bold 10pt Tahoma",
-					fontColor: "black",
-					labelOffset: -25,
+					fontColor: "white",
+					labelOffset: 25,
 					radius: 90
 				});
 				chart4.addSeries("Series A", [4, 2, 1, 1]);
 				chart4.render();
 
 				var chart5 = new Chart("test5");
-				chart5.setTheme(pkRed);
+				chart5.setTheme(pkGreen);
 				chart5.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 10pt Tahoma",
+					fontColor: "black",
+					labelOffset: -25,
+					radius: 90
+				});
+				chart5.addSeries("Series A", [4, 2, 1, 1]);
+				chart5.render();
+
+				var chart6 = new Chart("test6");
+				chart6.setTheme(pkRed);
+				chart6.addPlot("default", {
 					type: Pie,
 					font: "normal normal bold 14pt Tahoma",
 					fontColor: "white",
 					labelOffset: 40
 				});
-				chart5.addSeries("Series A", [{
+				chart6.addSeries("Series A", [{
 					y: 4,
 					text: "Red"
 				}, {
@@ -88,18 +114,18 @@
 					y: 1,
 					text: "Other"
 				}]);
-				chart5.render();
+				chart6.render();
 
-				var chart6 = new Chart("test6");
-				chart6.setTheme(pkRed);
-				chart6.addPlot("default", {
+				var chart7 = new Chart("test7");
+				chart7.setTheme(pkRed);
+				chart7.addPlot("default", {
 					type: Pie,
 					font: "normal normal bold 14pt Tahoma",
 					fontColor: "black",
 					labelOffset: 40,
 					startAngle: -45
 				});
-				chart6.addSeries("Series A", [{
+				chart7.addSeries("Series A", [{
 					y: 4,
 					text: "Red",
 					color: "red"
@@ -117,28 +143,28 @@
 					color: "white",
 					fontColor: "black"
 				}]);
-				chart6.render();
-
-				var chart7 = new Chart("test7");
-				chart7.setTheme(Adobebricks);
-				chart7.addPlot("default", {
-					type: Pie,
-					font: "normal normal bold 12pt Tahoma",
-					fontColor: "white",
-					radius: 80
-				});
-				chart7.addSeries("Series A", [4]);
 				chart7.render();
 
 				var chart8 = new Chart("test8");
-				chart8.setTheme(Algae);
+				chart8.setTheme(Adobebricks);
 				chart8.addPlot("default", {
 					type: Pie,
 					font: "normal normal bold 12pt Tahoma",
 					fontColor: "white",
 					radius: 80
 				});
-				chart8.addSeries("Series A", [{
+				chart8.addSeries("Series A", [4]);
+				chart8.render();
+
+				var chart9 = new Chart("test9");
+				chart9.setTheme(Algae);
+				chart9.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "white",
+					radius: 80
+				});
+				chart9.addSeries("Series A", [{
 					y: -1,
 					text: "Red",
 					color: "red"
@@ -156,27 +182,15 @@
 					color: "white",
 					fontColor: "black"
 				}]);
-				chart8.render();
-
-				var chart9 = new Chart("test9");
-				chart9.setTheme(Claro);
-				chart9.addPlot("default", {
-					type: Pie,
-					font: "normal normal bold 12pt Tahoma",
-					fontColor: "white",
-					radius: 80
-				});
-				chart9.addSeries("Series A", []);
 				chart9.render();
-				
+
 				var chart10 = new Chart("test10");
 				chart10.setTheme(Claro);
 				chart10.addPlot("default", {
 					type: Pie,
 					font: "normal normal bold 12pt Tahoma",
 					fontColor: "white",
-					radius: 80,
-					zeroDataMessage: "No Non-Zero Data"
+					radius: 80
 				});
 				chart10.addSeries("Series A", []);
 				chart10.render();
@@ -190,7 +204,19 @@
 					radius: 80,
 					zeroDataMessage: "No Non-Zero Data"
 				});
-				chart11.addSeries("Series A", [{
+				chart11.addSeries("Series A", []);
+				chart11.render();
+
+				var chart12 = new Chart("test12");
+				chart12.setTheme(Claro);
+				chart12.addPlot("default", {
+					type: Pie,
+					font: "normal normal bold 12pt Tahoma",
+					fontColor: "white",
+					radius: 80,
+					zeroDataMessage: "No Non-Zero Data"
+				});
+				chart12.addSeries("Series A", [{
 					y: 0,
 					text: "Red",
 					color: "red"
@@ -208,7 +234,7 @@
 					color: "white",
 					fontColor: "black"
 				}]);
-				chart11.render();
+				chart12.render();
 			});
 		</script>
 	</head>
@@ -219,38 +245,40 @@
 		<div id="test1" style="width: 300px; height: 300px;"></div>
 		<p>2: Pie with external labels and precision=0.</p>
 		<div id="test2" style="width: 300px; height: 300px;"></div>
-		<p>3/4: Two pies with internal and external labels with a constant radius.</p>
+		<p>3: Pie with `labelStyle="columns"`, a constant radius, and a `0` plot value.</p>
+		<div id="test3" style="width: 400px; height: 400px;"></div>
+		<p>4/5: Two pies with internal and external labels with a constant radius.</p>
 		<table border="1">
 			<tr>
-				<td>
-					<div id="test3" style="width: 300px; height: 300px;"></div>
-				</td>
 				<td>
 					<div id="test4" style="width: 300px; height: 300px;"></div>
 				</td>
-			</tr>
-		</table>
-		<p>5/6: Pie with internal custom labels and custom colors (#6 is rotated).</p>
-		<table border="1">
-			<tr>
 				<td>
 					<div id="test5" style="width: 300px; height: 300px;"></div>
 				</td>
+			</tr>
+		</table>
+		<p>6/7: Pie with internal custom labels and custom colors (#7 is rotated).</p>
+		<table border="1">
+			<tr>
 				<td>
 					<div id="test6" style="width: 300px; height: 300px;"></div>
 				</td>
+				<td>
+					<div id="test7" style="width: 300px; height: 300px;"></div>
+				</td>
 			</tr>
 		</table>
-		<p>7: Degenerated pie with 1 element.</p>
-		<div id="test7" style="width: 200px; height: 200px;"></div>
-		<p>8: Degenerated pie with 1 positive elements (out of 5).</p>
+		<p>8: Degenerated pie with 1 element.</p>
 		<div id="test8" style="width: 200px; height: 200px;"></div>
-		<p>9: Pie with no data.</p>
+		<p>9: Degenerated pie with 1 positive elements (out of 5).</p>
 		<div id="test9" style="width: 200px; height: 200px;"></div>
-		<p>10: Pie with all data zero (no data).</p>
+		<p>10: Pie with no data.</p>
 		<div id="test10" style="width: 200px; height: 200px;"></div>
-		<p>11: Pie with all data zero (no data) and a message.</p>
+		<p>11: Pie with all data zero (no data).</p>
 		<div id="test11" style="width: 200px; height: 200px;"></div>
+		<p>12: Pie with all data zero (no data) and a message.</p>
+		<div id="test12" style="width: 200px; height: 200px;"></div>
 		<p>That's all Folks!</p>
 	</body>
 </html>


### PR DESCRIPTION
Refs [No. 18988](https://bugs.dojotoolkit.org/ticket/18988#ticket).

Allows pie charts to specify a constant `radius` option when the `labels` option is `true` and the `labelStyles` option is `"columns"`, and allows labels for `0` plot values to be rendered without throwing errors.