### PR TITLE
Add guard to dojox/widget/Rotator destroy

### DIFF
--- a/widget/Rotator.js
+++ b/widget/Rotator.js
@@ -229,7 +229,7 @@ define([
 		destroy: function(){
 			// summary:
 			//		Destroys the Rotator and its DOM node.
-			array.forEach([this._controlSub, this.wfe], function(wfe) { wfe.remove() });
+			array.forEach([this._controlSub, this.wfe], function(wfe) { wfe && wfe.remove() });
 			domConstruct.destroy(this._domNode);
 			this.panes = [];
 		},


### PR DESCRIPTION
Refs No. [18989](https://bugs.dojotoolkit.org/ticket/18989).

Adds a guard to the handle destructors in `dojox/widget/Rotator#destroy` to prevent attempts to
destroy non-existent handlers.