### PR TITLE
Fix iOS Regular Expressions to Handle iOS 10

### DIFF
--- a/mobile/deviceTheme.js
+++ b/mobile/deviceTheme.js
@@ -162,22 +162,7 @@
 				[]
 			],
 			[
-				"Android 3",
-				"holodark",
-				[]
-			],
-			[
-				"Android 4",
-				"holodark",
-				[]
-			],
-			[
-				"Android 5",
-				"holodark",
-				[]
-			],
-			[
-				"Android 6",
+				"Android [3-9]",
 				"holodark",
 				[]
 			],
@@ -202,32 +187,12 @@
 				[]
 			],
 			[
-				"iPhone;.*OS 7_",
+				"iPhone;.*OS ([7-9]|1[0-9])_",
 				"ios7",
 				[]
 			],
 			[
-				"iPhone;.*OS 8_",
-				"ios7",
-				[]
-			],
-			[
-				"iPhone;.*OS 9_",
-				"ios7",
-				[]
-			],
-			[
-				"iPad;.*OS 7_",
-				"ios7",
-				[]
-			],
-			[
-				"iPad;.*OS 8_",
-				"ios7",
-				[]
-			],
-			[
-				"iPad;.*OS 9_",
+				"iPad;.*OS ([7-9]|1[0-9])_",
 				"ios7",
 				[]
 			],


### PR DESCRIPTION
This changes the Regex handling for iOS and Android so that it doesn't revert to the iPhone theme every time there's a new one. This puts iOS versions 7-19 to the ios7 theme. I did something similar for the android side.