### PR TITLE
Update dojox/form/Uploader to use dojo/request

### DIFF
--- a/form/tests/UploadFile.php.disabled
+++ b/form/tests/UploadFile.php.disabled
@@ -52,7 +52,7 @@ $download_path = "../tests/uploads/";	// same folder as above, but relative to t
 //
 // 	NOTE: maintain this path for JSON services
 //
-require("../../../dojo/tests/resources/JSON.php");
+require("../../../dojo/testsDOH/resources/JSON.php");
 $json = new Services_JSON();
 
 //


### PR DESCRIPTION
This pull request modifies `dojox/form/Uploader` to use `dojo/request` instead of its own `createXhr()` method. This allows users to use custom request providers as well as `dojo/request/registry` for uploads.