### PR TITLE
Add defaultPosition argument

### DIFF
--- a/charting/action2d/Tooltip.js
+++ b/charting/action2d/Tooltip.js
@@ -41,7 +41,8 @@ define(["dijit/Tooltip", "dojo/_base/lang", "dojo/_base/declare", "dojo/_base/wi
 		// the data description block for the widget parser
 		defaultParams: {
 			text: DEFAULT_TEXT,	// the function to produce a tooltip from the object
-            mouseOver: true
+            mouseOver: true,
+			defaultPosition: ["after-centered", "before-centered"]
 		},
 		optionalParams: {},	// no optional parameters
 
@@ -56,6 +57,7 @@ define(["dijit/Tooltip", "dojo/_base/lang", "dojo/_base/declare", "dojo/_base/wi
 			//		Optional keyword arguments object for setting parameters.
 			this.text = kwArgs && kwArgs.text ? kwArgs.text : DEFAULT_TEXT;
 			this.mouseOver = kwArgs && kwArgs.mouseOver != undefined ? kwArgs.mouseOver : true;
+			this.defaultPosition = kwArgs && kwArgs.defaultPosition != undefined ? kwArgs.defaultPosition : ["after-centered", "before-centered"];
 			this.connect();
 		},
 		
@@ -76,7 +78,7 @@ define(["dijit/Tooltip", "dojo/_base/lang", "dojo/_base/declare", "dojo/_base/wi
 			if(!o.shape || (this.mouseOver && o.type !== "onmouseover") || (!this.mouseOver && o.type !== "onclick")){ return; }
 			
 			// calculate relative coordinates and the position
-			var aroundRect = {type: "rect"}, position = ["after-centered", "before-centered"];
+			var aroundRect = {type: "rect"}, position = this.defaultPosition;
 			switch(o.element){
 				case "marker":
 					aroundRect.x = o.cx;


### PR DESCRIPTION
I have run into a problem where the current default  ["after-centered", "before-centered"] does not work when in a dialog and the chart is to the far right with a long tooltip text. Adding this extra parameter fixes my issue.