### PR TITLE
Compare element to window object rather than checking for scrollTo property

### DIFF
--- a/fx/scroll.js
+++ b/fx/scroll.js
@@ -1,5 +1,5 @@
-define(["dojo/_base/kernel","dojo/_base/lang", "dojo/_base/fx", "dojox/fx/_base","dojox/fx/_core","dojo/dom-geometry","dojo/_base/sniff"],
-	function (kernel, lang, baseFx, fxExt, Line, domGeom, has){
+define(["dojo/_base/kernel","dojo/_base/lang", "dojo/_base/fx", "dojo/_base/window", "dojox/fx/_base","dojox/fx/_core","dojo/dom-geometry","dojo/_base/sniff"],
+	function (kernel, lang, baseFx, win, fxExt, Line, domGeom, has){
 	kernel.experimental("dojox.fx.scroll");
 	var fx = lang.getObject("dojox.fx",true);
 	fxExt.smoothScroll = function(/* Object */args){
@@ -15,9 +15,8 @@ define(["dojo/_base/kernel","dojo/_base/lang", "dojo/_base/fx", "dojox/fx/_base"
 	
 		if(!args.target){ args.target = domGeom.position(args.node); }
 	
-		var isWindow = lang[(has("ie") ? "isObject" : "isFunction")](args["win"].scrollTo),
-			delta = { x: args.target.x, y: args.target.y }
-		;
+		var isWindow = args["win"] === win.global,
+			delta = { x: args.target.x, y: args.target.y };
 		if(!isWindow){
 			var winPos = domGeom.position(args.win);
 			delta.x -= winPos.x;


### PR DESCRIPTION
The `scrollTo` method being used to check for the window object here exists on elements in firefox, causing `isWindow` to be true all the time. This would replace the check with a reference comparison to the `global` object in `dojo/_base/window`.

Fixes [19028](https://bugs.dojotoolkit.org/ticket/19028)