### PR TITLE
Google Closure Compiler upgrade: Removing duplicate object keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+html-report
+sauce_connect.log
+coverage-final.json
+npm-debug.log

--- a/charting/plot2d/commonStacked.js
+++ b/charting/plot2d/commonStacked.js
@@ -152,42 +152,6 @@ define([
 
 			return values;
 		},
-
-		getIndexValue: function(series, i, index, isNullValue){
-			var value = 0, v, j;
-			for(j = 0; j <= i; ++j){
-				v = series[j].data[index];
-				if(!isNullValue(v)){
-					if(isNaN(v)){ v = v.y || 0; }
-					value += v;
-				}
-			}
-			return value;
-		},
-
-		getValue: function(series, i, x, isNullValue){
-			var value = null, j, z;
-			for(j = 0; j <= i; ++j){
-				for(z = 0; z < series[j].data.length; z++){
-					v = series[j].data[z];
-					if(!isNullValue(v)){
-						if(v.x == x){
-							if(!value){
-								value = {x: x};
-							}
-							if(v.y != null){
-								if(value.y == null){
-									value.y = 0;
-								}
-								value.y += v.y;
-							}
-							break;
-						}else if(v.x > x){break;}
-					}
-				}
-			}
-			return value;
-		},
 		
 		getIndexValue: function(series, i, index, isNullValue){
 			var value = 0, v, j, pvalue;

--- a/grid/TreeGrid.js
+++ b/grid/TreeGrid.js
@@ -234,7 +234,6 @@ var TreePath = declare("dojox.grid.TreePath", null, {
 	grid: null,
 	store: null,
 	cell: null,
-	item: null,
 
 	constructor: function(/*String|Integer[]|Integer|dojox.grid.TreePath*/ path, /*dojox.grid.TreeGrid*/ grid){
 		if(lang.isString(path)){

--- a/grid/enhanced/nls/EnhancedGrid.js
+++ b/grid/enhanced/nls/EnhancedGrid.js
@@ -30,7 +30,6 @@ define({ root:
 "he": true,
 "hr": true,
 "hu": true,
-"hr": true,
 "id": true,
 "it": true,
 "ja": true,

--- a/grid/enhanced/nls/Filter.js
+++ b/grid/enhanced/nls/Filter.js
@@ -103,7 +103,6 @@ define({ root:
 "he": true,
 "hr": true,
 "hu": true,
-"hr": true,
 "id": true,
 "it": true,
 "ja": true,

--- a/grid/enhanced/nls/Pagination.js
+++ b/grid/enhanced/nls/Pagination.js
@@ -38,7 +38,6 @@ define({ root:
 "he": true,
 "hr": true,
 "hu": true,
-"hr": true,
 "id": true,
 "it": true,
 "ja": true,

--- a/highlight/languages/groovy.js
+++ b/highlight/languages/groovy.js
@@ -8,10 +8,10 @@ define(["../_base"], function(dh){
 				'finally': 1, 'implements': 1, 'import': 1, 'extends': 1,
 				'long': 1, 'throw': 1, 'instanceof': 2, 'static': 1,
 				'protected': 1, 'boolean': 1, 'interface': 2, 'native': 1,
-				'if': 1, 'public': 1, 'new': 1, 'do': 1, 'return': 1,
-				'goto': 1, 'package': 2, 'void': 2, 'short': 1, 'else': 1,
+				'if': 1, 'public': 1, 'do': 1, 'return': 1,
+				'goto': 1, 'package': 2, 'void': 2, 'else': 1,
 				'break': 1, 'new': 1, 'strictfp': 1, 'super': 1, 'true': 1,
-				'class': 1, 'synchronized': 1, 'case': 1, 'this': 1, 'short': 1,
+				'class': 1, 'synchronized': 1, 'case': 1, 'short': 1,
 				'throws': 1, 'transient': 1, 'double': 1, 'volatile': 1,
 				'try': 1, 'this': 1, 'switch': 1, 'continue': 1, 'def': 2
 			}

--- a/highlight/languages/java.js
+++ b/highlight/languages/java.js
@@ -8,10 +8,10 @@ define(["../_base"], function(dh){
 				'finally': 1, 'implements': 1, 'import': 1, 'extends': 1,
 				'long': 1, 'throw': 1, 'instanceof': 2, 'static': 1,
 				'protected': 1, 'boolean': 1, 'interface': 2, 'native': 1,
-				'if': 1, 'public': 1, 'new': 1, 'do': 1, 'return': 1,
-				'goto': 1, 'package': 2, 'void': 2, 'short': 1, 'else': 1,
+				'if': 1, 'public': 1, 'do': 1, 'return': 1,
+				'goto': 1, 'package': 2, 'void': 2, 'else': 1,
 				'break': 1, 'new': 1, 'strictfp': 1, 'super': 1, 'true': 1,
-				'class': 1, 'synchronized': 1, 'case': 1, 'this': 1, 'short': 1,
+				'class': 1, 'synchronized': 1, 'case': 1, 'short': 1,
 				'throws': 1, 'transient': 1, 'double': 1, 'volatile': 1,
 				'try': 1, 'this': 1, 'switch': 1, 'continue': 1
 			}

--- a/highlight/languages/pygments/javascript.js
+++ b/highlight/languages/pygments/javascript.js
@@ -18,7 +18,7 @@ define(["../../_base"], function(dh){
 					"Array": 1, "Boolean": 1, "Date": 1, "Error": 1, "Function": 1, "Math": 1,
 					"netscape": 1, "Number": 1, "Object": 1, "Packages": 1, "RegExp": 1,
 					"String": 1, "sun": 1, "decodeURI": 1, "decodeURIComponent": 1,
-					"encodeURI": 1, "encodeURIComponent": 1, "Error": 1, "eval": 1,
+					"encodeURI": 1, "encodeURIComponent": 1, "eval": 1,
 					"isFinite": 1, "isNaN": 1, "parseFloat": 1, "parseInt": 1, "document": 1,
 					"window": 1
 				},

--- a/mdnd/adapter/DndFromDojo.js
+++ b/mdnd/adapter/DndFromDojo.js
@@ -16,10 +16,6 @@ define(["dojo/_base/kernel",
 	
 		// dropIndicatorSize: Object
 		//		size by default of dropIndicator (display only into a D&D Area)
-		dropIndicatorSize : {'w':0,'h':50},
-	
-		// dropIndicatorSize: Object
-		//		size by default of dropIndicator (display only into a D&D Area)
 		dropIndicatorSize: {'w':0,'h':50},
 	
 		// _areaManager: Object

--- a/rpc/tests/Yahoo.js
+++ b/rpc/tests/Yahoo.js
@@ -143,7 +143,7 @@ doh.register("dojox.rpc.tests.yahoo",
 			name: "#13, Yahoo Local::getCollection",
 			timeout: dojox.rpc.tests.yahooService.TEST_METHOD_LONG_TIMEOUT,
 			runTest: dojox.rpc.tests.yahooService._testMethod({
-				expectedResult: "getCollection",
+				name: "getCollection",
 				parameters: {collection_id: "1000031487"},
 				expectedResult: "Result"
 			})

--- a/widget/FilePicker.js
+++ b/widget/FilePicker.js
@@ -11,10 +11,6 @@ dojo.declare("dojox.widget._FileInfoPane",
 	//		a pane to display the information for the currently-selected
 	//		file
 	
-	// templateString: string
-	//		delete our template string
-	templateString: "",
-	
 	// templateString: String
 	//		The template to be used to construct the widget.
 	templateString: dojo.cache("dojox.widget", "FilePicker/_FileInfoPane.html"),


### PR DESCRIPTION
Dojo 1.x uses currently the Google Closure Compiler v20160911.

It is currently impossible to upgrade the Google Closure Compiler to a newer version. The reason is — there is an incompatibility issue, when using the Google Closure Compiler to process Dojo applications: duplicate object keys.

This pull request introduces changes to the Dojo 1.x's source code that remove all the occurrences of duplicate object keys in code.