### PR TITLE
Update Axes.js to access Label correctly.

### DIFF
--- a/drawing/annotations/Label.js
+++ b/drawing/annotations/Label.js
@@ -1,8 +1,6 @@
 define(["exports", "dojo/_base/lang", "../util/oo", "../stencil/Text"],
 function(exports, lang, oo, Text){
 
-// TODO: why not just return Label?
-
 exports.Label = oo.declare(
 	Text,
 	function(/*Object*/options){

--- a/drawing/stencil/_Base.js
+++ b/drawing/stencil/_Base.js
@@ -1,6 +1,6 @@
 define(["dojo", "dojo/fx/easing", "../util/oo", "../annotations/BoxShadow", 
   "../annotations/Angle", "../annotations/Label", "../defaults"], 
-function(dojo, easing, oo, BoxShadow, Angle, LabelExports, defaults){
+function(dojo, easing, oo, BoxShadow, Angle, Label, defaults){
 
 /*=====
 var StencilArgs = {
@@ -844,7 +844,7 @@ var Base = oo.declare(
 			// text: String
 			//		The text to set as the label.
 			if(!this._label){
-				this._label = new LabelExports.Label({
+				this._label = new Label.Label({
 					text:text,
 					util:this.util,
 					mouse:this.mouse,

--- a/drawing/tools/custom/Axes.js
+++ b/drawing/tools/custom/Axes.js
@@ -1,6 +1,6 @@
 define(["dojo/_base/lang", "../../util/oo", "../../manager/_registry", "../../stencil/Path",
 	"../../annotations/Arrow", "../../annotations/Label", "../../tools/custom/Vector"],
-function(lang, oo, registry, StencilPath, Arrow, LabelExports, Vector){
+function(lang, oo, registry, StencilPath, Arrow, Label, Vector){
 
 var Axes = oo.declare(
 	StencilPath,
@@ -101,14 +101,14 @@ var Axes = oo.declare(
 
 			// NOTE: Not passing style into text because it's changing it
 			var props = {align:"middle", valign:"middle", util:this.util, annotation:true, container:this.container, mouse:this.mouse, stencil:this};
-			this.labelX = new LabelExports.Label(lang.mixin(props,{
+			this.labelX = new Label.Label(lang.mixin(props,{
 				labelPosition:this.setLabelX
 			}));
-			this.labelY = new LabelExports.Label(lang.mixin(props,{
+			this.labelY = new Label.Label(lang.mixin(props,{
 				labelPosition:this.setLabelY
 			}));
 			if(this.style.zAxisEnabled){
-				this.labelZ = new LabelExports.Label(lang.mixin(props,{
+				this.labelZ = new Label.Label(lang.mixin(props,{
 					labelPosition:this.setLabelZ
 				}));
 			}

--- a/drawing/tools/custom/Axes.js
+++ b/drawing/tools/custom/Axes.js
@@ -1,6 +1,6 @@
 define(["dojo/_base/lang", "../../util/oo", "../../manager/_registry", "../../stencil/Path",
 	"../../annotations/Arrow", "../../annotations/Label", "../../tools/custom/Vector"],
-function(lang, oo, registry, StencilPath, Arrow, Label, Vector){
+function(lang, oo, registry, StencilPath, Arrow, LabelExports, Vector){
 
 var Axes = oo.declare(
 	StencilPath,
@@ -101,14 +101,14 @@ var Axes = oo.declare(
 
 			// NOTE: Not passing style into text because it's changing it
 			var props = {align:"middle", valign:"middle", util:this.util, annotation:true, container:this.container, mouse:this.mouse, stencil:this};
-			this.labelX = new Label(lang.mixin(props,{
+			this.labelX = new LabelExports.Label(lang.mixin(props,{
 				labelPosition:this.setLabelX
 			}));
-			this.labelY = new Label(lang.mixin(props,{
+			this.labelY = new LabelExports.Label(lang.mixin(props,{
 				labelPosition:this.setLabelY
 			}));
 			if(this.style.zAxisEnabled){
-				this.labelZ = new Label(lang.mixin(props,{
+				this.labelZ = new LabelExports.Label(lang.mixin(props,{
 					labelPosition:this.setLabelZ
 				}));
 			}


### PR DESCRIPTION
The AMD conversion of dojox/drawing used "exports" to resolve a circular module dependency.  Update Axes.js to access the Label module correctly.