### PR TITLE
Remove noop progress listener from dojox/form/uploader/_HTML5

### DIFF
--- a/form/uploader/_HTML5.js
+++ b/form/uploader/_HTML5.js
@@ -4,26 +4,8 @@ define([
 	"dojo/_base/array",
 	"dojo",
 	"dojo/request",
-	"dojo/request/xhr",
 	"dojo/has"
-],function(declare, lang, arrayUtil, dojo, request, xhr, has){
-	function noop(){}
-
-	if(has("native-xhr2")){
-		// Ensure a progress handler is set before XMLHttpRequest#open()
-		// is called so the progress handler attached in
-		// Uploader#uploadWithFormData() will fire
-		xhr._create = (function(create){
-			return function(){
-				var _xhr = create();
-
-				_xhr.upload.addEventListener('progress', noop, false);
-
-				return _xhr;
-			};
-		})(xhr._create);
-	}
-
+],function(declare, lang, arrayUtil, dojo, request, has){
 	return declare("dojox.form.uploader._HTML5", [], {
 		// summary:
 		//		A mixin for dojox/form/Uploader that adds HTML5 multiple-file upload capabilities and
@@ -120,6 +102,7 @@ define([
 					method: "POST",
 					data: fd,
 					handleAs: "json",
+					uploadProgress: true,
 					headers: {
 						Accept: "application/json"
 					}
@@ -147,7 +130,6 @@ define([
 				// Disconnect event handlers when done
 				deferred.response.xhr.removeEventListener("load", onProgressHandler, false);
 				deferred.response.xhr.upload.removeEventListener("progress", onProgressHandler, false);
-				deferred.response.xhr.upload.removeEventListener("progress", noop, false);
 
 				deferred = null;
 			}


### PR DESCRIPTION
**Note:** This PR depends on dojo/dojo#274.

This PR updates `dojox/form/uploader/_HTML5` to make use of the new `uploadProgress` option that's now supported by `dojo/request/xhr`. Using this property allows for the removal of a previously required noop progress event on an underlying `XMLHttpRequest` object that caused all request to be preflighted. 