### PR TITLE
Fixes #286: Bug in dojox/html/metrics' getTextBox function when the passed text contains white-spaces

### DIFF
--- a/html/metrics.js
+++ b/html/metrics.js
@@ -69,6 +69,8 @@ define(["dojo/_base/kernel","dojo/_base/lang", "dojo/_base/sniff", "dojo/ready",
 		var m, s;
 		if(!measuringNode){
 			m = measuringNode = Window.doc.createElement("div");
+      // Due to fixing the parent node's width below, texts which contain white-spaces would be wrapped. Avoid this.
+      m.style.whiteSpace = "nowrap";
 			// Container that we can set constraints on so that it doesn't
 			// trigger a scrollbar.
 			var c = Window.doc.createElement("div");

--- a/html/metrics.js
+++ b/html/metrics.js
@@ -69,8 +69,8 @@ define(["dojo/_base/kernel","dojo/_base/lang", "dojo/_base/sniff", "dojo/ready",
 		var m, s;
 		if(!measuringNode){
 			m = measuringNode = Window.doc.createElement("div");
-      // Due to fixing the parent node's width below, texts which contain white-spaces would be wrapped. Avoid this.
-      m.style.whiteSpace = "nowrap";
+			// Due to fixing the parent node's width below, texts which contain white-spaces would be wrapped. Avoid this.
+			m.style.whiteSpace = "nowrap";
 			// Container that we can set constraints on so that it doesn't
 			// trigger a scrollbar.
 			var c = Window.doc.createElement("div");


### PR DESCRIPTION
Very simple fix for bug in dojox/html/metrics' getTextBox function when the passed text contains white-spaces
Fixes #286