### PR TITLE
Fix dom rendering of attributes with empty data

### DIFF
--- a/dtl/dom.js
+++ b/dtl/dom.js
@@ -916,7 +916,7 @@ define([
 			if(dd.BOOLS[key]){
 				value = !(value == "false" || value == "undefined" || !value);
 			}
-			if(value !== this.contents){
+			if(value !== this.contents || value === ""){
 				this.contents = value;
 				return buffer.setAttribute(key, value);
 			}

--- a/dtl/tests/dom/tag.js
+++ b/dtl/tests/dom/tag.js
@@ -320,6 +320,14 @@ doh.register("dojox.dtl.dom.tag",
 			var template = new dd.DomTemplate('<div tabIndex="-1"></div>');
 			//the following should not throw errors in IE
 			dd.tests.dom.util.render(template, context);
-		}
+		},
+		function test_attribute_with_empty_data(t){
+		    var dd = dojox.dtl;
+
+		    var template = new dd.DomTemplate('<div attr="{{fruit}}"></div>');
+		    var context = new dd.Context({ fruit : "" });
+		    const htmlResult = template.render(context).getParent().outerHTML;
+		    t.is('<div attr=""></div>', htmlResult);
+		},
 	]
 );


### PR DESCRIPTION
Fixes #288.

The attribute value wasn't updated when the DTL expression inside of it resulted in an empty string. The side effect was that the attribute's value remained with the DTL expression inside of it (see #288 for more details).

Added a test case that has a much smaller code footprint than the example in the issue linked above.