### PR TITLE
Fix rendering for value attribute on option tag

### DIFF
--- a/dtl/dom.js
+++ b/dtl/dom.js
@@ -223,9 +223,6 @@ define([
 					value = node.className || value;
 				}else if(key == "for"){
 					value = node.htmlFor || value;
-				}else if(key == "value" && node.value == node.innerHTML){
-					// Sometimes .value is set the same as the contents of the item (button)
-					continue;
 				}else if(node.getAttribute){
 					value = node.getAttribute(key, 2) || value;
 					if(key == "href" || key == "src"){

--- a/dtl/tests/dom/tag.js
+++ b/dtl/tests/dom/tag.js
@@ -329,5 +329,25 @@ doh.register("dojox.dtl.dom.tag",
 		    const htmlResult = template.render(context).getParent().outerHTML;
 		    t.is('<div attr=""></div>', htmlResult);
 		},
+		function test_option_tag_with_same_value_attribute_and_innerHTML(t){
+		    var dd = dojox.dtl;
+
+			const html =
+			  '<div>'
+			+ '<select>'
+			+ '<option value="{{fruit}}">{{fruit}}</option>'
+			+ '</select>'
+			+ '</div>';
+			var template = new dd.DomTemplate(html);
+		    var context = new dd.Context({ fruit : "Fruit" });
+			const htmlResult = template.render(context).getParent().outerHTML;
+			const htmlExpected =
+			  '<div>'
+			+ '<select>'
+			+ '<option value="Fruit">Fruit</option>'
+			+ '</select>'
+			+ '</div>';
+		    t.is(htmlExpected, htmlResult);
+		},
 	]
 );


### PR DESCRIPTION
Fixes #295 

I found that there was an explicit check in the tokenization code that prevented the value attribute from being added to the token list. This check verified whether the node had the same value for both its `value` property and its `innerHTML` property. This piece of code was also accompanied by the comment: "`Sometimes .value is set the same as the contents of the item (button)`", which helped me discover that the same issue happens for the button tag as well. I couldn't pinpoint the original intent of the condition or the comment and git blame didn't help either.

I think it is safe to say though that this behavior doesn't happen for other tags basically because the condition wasn't met. For some of them that I tested for either the `node.value` was undefined (eg: `div`s, `span`s...) or the innerHTML content was empty (`input`s).