### PR TITLE
Improve CSP compliance for gfx and charting

### DIFF
--- a/charting/Chart.js
+++ b/charting/Chart.js
@@ -1,10 +1,10 @@
 define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "dojo/dom-style",
 	"dojo/dom", "dojo/dom-geometry", "dojo/dom-construct","dojo/_base/Color", "dojo/sniff",
-	"./Element", "./SimpleTheme", "./Series", "./axis2d/common", "dojox/gfx/shape",
+	"./Element", "./SimpleTheme", "./Series", "./axis2d/common", "./plot2d/common", "dojox/gfx/shape",
 	"dojox/gfx", "dojo/has!dojo-bidi?./bidi/Chart", "dojox/lang/functional", "dojox/lang/functional/fold", "dojox/lang/functional/reversed"],
 	function(dojox, lang, arr, declare, domStyle,
 	 		 dom, domGeom, domConstruct, Color, has,
-	 		 Element, SimpleTheme, Series, common, shape,
+			 Element, SimpleTheme, Series, common, plot2dCommon, shape,
 	 		 g, BidiChart, func){
 	/*=====
 	var __ChartCtorArgs = {
@@ -44,13 +44,29 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 	=====*/
 
 	var dc = lang.getObject("charting", true, dojox),
-		clear = func.lambda("item.clear()"),
-		purge = func.lambda("item.purgeGroup()"),
-		destroy = func.lambda("item.destroy()"),
-		makeClean = func.lambda("item.dirty = false"),
-		makeDirty = func.lambda("item.dirty = true"),
-		getName = func.lambda("item.name"),
 		defaultMargins = {l: 10, t: 10, r: 10, b: 10};
+
+	function clear (item) {
+		return item.clear();
+	}
+
+	function destroy (item) {
+		return item.destroy();
+	}
+
+	function makeClean (item) {
+		item.dirty = false;
+		return false;
+	}
+
+	function makeDirty (item) {
+		item.dirty = true;
+		return true;
+	}
+
+	function getName (item) {
+		return item.name;
+	}
 
 	var Chart = declare(has("dojo-bidi")? "dojox.charting.NonBidiChart" : "dojox.charting.Chart", null, {
 		// summary:
@@ -124,7 +140,7 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 		//	|			)
 		//	|			.render();
 		//	|	});
-		
+
 		// theme: dojox/charting/SimpleTheme?
 		//		An optional theme to use for styling the chart.
 		// axes: dojox/charting/axis2d/Base{}?
@@ -171,7 +187,7 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 			this.titlePos  = kwArgs.titlePos;
 			this.titleFont = kwArgs.titleFont;
 			this.titleFontColor = kwArgs.titleFontColor;
-			this.titleAlign = kwArgs.titleAlign; // This can be middle, left, right, or edge 
+			this.titleAlign = kwArgs.titleAlign; // This can be middle, left, right, or edge
 															 // edge is left or right aligned with chart plot edge depending on bidi.
 			this.chartTitle = null;
 			this.htmlLabels = true;
@@ -887,7 +903,7 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 				clearTimeout(this._delayedRenderHandle);
 				this._delayedRenderHandle = null;
 			}
-			
+
 			if(this.theme){
 				this.theme.clear();
 			}
@@ -926,9 +942,9 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 			//this.theme.defineColors({num: requiredColors, cache: false});
 
 			// clear old shapes
-			arr.forEach(this.series, purge);
-			func.forIn(this.axes, purge);
-			arr.forEach(this.stack,  purge);
+			arr.forEach(this.series, plot2dCommon.purgeGroup);
+			func.forIn(this.axes, plot2dCommon.purgeGroup);
+			arr.forEach(this.stack, plot2dCommon.purgeGroup);
 			var children = this.surface.children;
 			// starting with 1.9 the registry is optional and thus dispose is
 			if(shape.dispose){
@@ -982,7 +998,7 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 				labelType = forceHtmlLabels || !has("ie") && !has("opera") && this.htmlLabels ? "html" : "gfx",
 				tsize = g.normalizedLength(g.splitFontString(this.titleFont).size),
 				tBox = g._base._getTextBox(this.title,{ font: this.titleFont });
-				
+
 			var titleAlign = this.titleAlign;
 			var isRtl = has("dojo-bidi") && this.isRightToLeft();
 			var posX = dim.width/2; // Default is middle.
@@ -1200,11 +1216,11 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 			}
 		},
 		setDir : function(dir){
-			return this; 
+			return this;
 		},
 		_resetLeftBottom: function(axis){
 		},
-		formatTruncatedLabel: function(element, label, labelType){			
+		formatTruncatedLabel: function(element, label, labelType){
 		}
 	});
 
@@ -1256,6 +1272,6 @@ define(["../main", "dojo/_base/lang", "dojo/_base/array","dojo/_base/declare", "
 			plot.initializeScalers(plotArea, stats);
 		});
 	}
-	
+
 	return has("dojo-bidi")? declare("dojox.charting.Chart", [Chart, BidiChart]) : Chart;
 });

--- a/charting/plot2d/Bars.js
+++ b/charting/plot2d/Bars.js
@@ -1,16 +1,16 @@
 define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has", "./CartesianBase", "./_PlotEvents", "./common",
-	"dojox/gfx/fx", "dojox/lang/utils", "dojox/lang/functional", "dojox/lang/functional/reversed"], 
-	function(lang, arr, declare, has, CartesianBase, _PlotEvents, dc, fx, du, df, dfr){
-		
+	"dojox/gfx/fx", "dojox/lang/utils", "dojox/lang/functional"],
+	function(lang, arr, declare, has, CartesianBase, _PlotEvents, dc, fx, du, df){
+
 	/*=====
 	declare("dojox.charting.plot2d.__BarCtorArgs", dojox.charting.plot2d.__DefaultCtorArgs, {
 		// summary:
 		//		Additional keyword arguments for bar charts.
-	
+
 		// minBarSize: Number?
 		//		The minimum size for a bar in pixels.  Default is 1.
 		minBarSize: 1,
-	
+
 		// maxBarSize: Number?
 		//		The maximum size for a bar in pixels.  Default is 1.
 		maxBarSize: 1,
@@ -47,15 +47,14 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 		// fontColor: String|dojo.Color?
 		//		The color to be used for any text-based elements on the plot.
 		fontColor:	"",
-		
+
 		// enableCache: Boolean?
 		//		Whether the bars rect are cached from one rendering to another. This improves the rendering performance of
 		//		successive rendering but penalize the first rendering.  Default false.
 		enableCache: false
 	});
 	=====*/
-	var purgeGroup = dfr.lambda("item.purgeGroup()");
-	
+
 	var alwaysFalse = function(){ return false; }
 
 	return declare("dojox.charting.plot2d.Bars", [CartesianBase, _PlotEvents], {
@@ -106,7 +105,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 			t = stats.hmax, stats.hmax = stats.vmax, stats.vmax = t;
 			return stats; // Object
 		},
-		
+
 		createRect: function(run, creator, params){
 			var rect;
 			if(this.opt.enableCache && run._rectFreePool.length > 0){
@@ -149,7 +148,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 			this.resetEvents();
 			var s;
 			if(this.dirty){
-				arr.forEach(this.series, purgeGroup);
+				arr.forEach(this.series, dc.purgeGroup);
 				this._eventSeries = {};
 				this.cleanGroup();
 				s = this.getGroup();
@@ -159,7 +158,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 				ht = this._hScaler.scaler.getTransformerFromModel(this._hScaler),
 				vt = this._vScaler.scaler.getTransformerFromModel(this._vScaler),
 				baseline = Math.max(this._hScaler.bounds.lower,
-					this._hAxis ? this._hAxis.naturalBaseline : 0),				
+					this._hAxis ? this._hAxis.naturalBaseline : 0),
 				baselineWidth = ht(baseline),
 				events = this.events();
 			var bar = this.getBarProperties();
@@ -167,11 +166,11 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 			var actualLength = this.series.length;
 			arr.forEach(this.series, function(serie){if(serie.hidden){actualLength--;}});
 			var z = actualLength;
-			
+
 			// Collect and calculate all values
 			var extractedValues = this.extractValues(this._vScaler);
 			extractedValues = this.rearrangeValues(extractedValues, ht, baselineWidth);
-			
+
 			for(var i = 0; i < this.series.length; i++){
 				var run = this.series[i];
 				if(!this.dirty && !run.dirty){
@@ -193,7 +192,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 				z--;
 
 				var	eventSeries = new Array(run.data.length);
-				s = run.group;	
+				s = run.group;
 				var indexed = arr.some(run.data, function(item){
 					return typeof item == "number" || (item && !item.hasOwnProperty("x"));
 				});
@@ -231,13 +230,13 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 									this._animateBar(sshape, offsets.l + baselineWidth, -w);
 								}
 							}
-							
+
 							var specialFill = this._plotFill(finalTheme.series.fill, dim, offsets);
 							specialFill = this._shapeFill(specialFill, rect);
 							var shape = this.createRect(run, s, rect).setFill(specialFill).setStroke(finalTheme.series.stroke);
 							if(shape.setFilter && finalTheme.series.filter){
 								shape.setFilter(finalTheme.series.filter);
-							}							
+							}
 							run.dyn.fill   = shape.getFill();
 							run.dyn.stroke = shape.getStroke();
 							if(events){
@@ -340,7 +339,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 				return v(0.5) || h(value);
 			}
 			return v(isNaN(value.x) ? 0.5 : value.x + 0.5) || value.y === null || h(value.y);
-		},		
+		},
 		getBarProperties: function(){
 			var f = dc.calculateBarSize(this._vScaler.bounds.scale, this.opt);
 			return {gap: f.gap, height: f.size, thickness: 0};

--- a/charting/plot2d/Bubble.js
+++ b/charting/plot2d/Bubble.js
@@ -1,9 +1,7 @@
-define(["dojo/_base/lang", "dojo/_base/declare", "dojo/_base/array", "dojo/has", 
-		"./CartesianBase", "./_PlotEvents", "./common", "dojox/lang/functional", "dojox/lang/functional/reversed",
-		"dojox/lang/utils", "dojox/gfx/fx"], 
-	function(lang, declare, arr, has, CartesianBase, _PlotEvents, dc, df, dfr, du, fx){
-
-	var purgeGroup = dfr.lambda("item.purgeGroup()");
+define(["dojo/_base/lang", "dojo/_base/declare", "dojo/_base/array", "dojo/has",
+		"./CartesianBase", "./_PlotEvents", "./common", "dojox/lang/functional",
+		"dojox/lang/utils", "dojox/gfx/fx"],
+	function(lang, declare, arr, has, CartesianBase, _PlotEvents, dc, df, du, fx){
 
 	return declare("dojox.charting.plot2d.Bubble", [CartesianBase, _PlotEvents], {
 		// summary:
@@ -60,7 +58,7 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/_base/array", "dojo/has",
 			this.resetEvents();
 			this.dirty = this.isDirty();
 			if(this.dirty){
-				arr.forEach(this.series, purgeGroup);
+				arr.forEach(this.series, dc.purgeGroup);
 				this._eventSeries = {};
 				this.cleanGroup();
 				s = this.getGroup();
@@ -106,7 +104,7 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/_base/array", "dojo/has",
 					continue;
 				}
 				s = run.group;
-                
+
 				var frontCircles = null, outlineCircles = null, shadowCircles = null, styleFunc = this.opt.styleFunc;
 
 				var getFinalTheme = function(item){

--- a/charting/plot2d/Candlesticks.js
+++ b/charting/plot2d/Candlesticks.js
@@ -1,8 +1,6 @@
 define(["dojo/_base/lang", "dojo/_base/declare", "dojo/_base/array", "dojo/has", "./CartesianBase", "./_PlotEvents", "./common",
-		"dojox/lang/functional", "dojox/lang/functional/reversed", "dojox/lang/utils", "dojox/gfx/fx"], 
-	function(lang, declare, arr, has, CartesianBase, _PlotEvents, dc, df, dfr, du, fx){
-
-	var purgeGroup = dfr.lambda("item.purgeGroup()");
+		"dojox/lang/functional", "dojox/lang/utils", "dojox/gfx/fx"],
+	function(lang, declare, arr, has, CartesianBase, _PlotEvents, dc, df, du, fx){
 
 	//	Candlesticks are based on the Bars plot type; we expect the following passed
 	//	as values in a series:
@@ -106,7 +104,7 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/_base/array", "dojo/has",
 			this.dirty = this.isDirty();
 			var s;
 			if(this.dirty){
-				arr.forEach(this.series, purgeGroup);
+				arr.forEach(this.series, dc.purgeGroup);
 				this._eventSeries = {};
 				this.cleanGroup();
 				s = this.getGroup();
@@ -136,7 +134,7 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/_base/array", "dojo/has",
 					continue;
 				}
 				s = run.group;
-                
+
 				for(var j = 0; j < run.data.length; ++j){
 					var v = run.data[j];
 					if(!this.isNullValue(v)){

--- a/charting/plot2d/Columns.js
+++ b/charting/plot2d/Columns.js
@@ -1,8 +1,6 @@
 define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has", "./CartesianBase", "./_PlotEvents", "./common",
-		"dojox/lang/functional", "dojox/lang/functional/reversed", "dojox/lang/utils", "dojox/gfx/fx"],
-	function(lang, arr, declare, has, CartesianBase, _PlotEvents, dc, df, dfr, du, fx){
-
-	var purgeGroup = dfr.lambda("item.purgeGroup()");
+		"dojox/lang/functional", "dojox/lang/utils", "dojox/gfx/fx"],
+	function(lang, arr, declare, has, CartesianBase, _PlotEvents, dc, df, du, fx){
 
 	var alwaysFalse = function(){ return false; };
 
@@ -85,7 +83,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 			this.dirty = this.isDirty();
 			var s;
 			if(this.dirty){
-				arr.forEach(this.series, purgeGroup);
+				arr.forEach(this.series, dc.purgeGroup);
 				this._eventSeries = {};
 				this.cleanGroup();
 				s = this.getGroup();

--- a/charting/plot2d/Default.js
+++ b/charting/plot2d/Default.js
@@ -1,6 +1,6 @@
 define(["dojo/_base/lang", "dojo/_base/declare", "dojo/_base/array", "dojo/has",
-		"./CartesianBase", "./_PlotEvents", "./common", "dojox/lang/functional", "dojox/lang/functional/reversed", "dojox/lang/utils", "dojox/gfx/fx"],
-	function(lang, declare, arr, has, CartesianBase, _PlotEvents, dc, df, dfr, du, fx){
+		"./CartesianBase", "./_PlotEvents", "./common", "dojox/lang/functional", "dojox/lang/utils", "dojox/gfx/fx"],
+	function(lang, declare, arr, has, CartesianBase, _PlotEvents, dc, df, du, fx){
 
 	/*=====
 	declare("dojox.charting.plot2d.__DefaultCtorArgs", dojox.charting.plot2d.__CartesianCtorArgs, {
@@ -104,8 +104,6 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/_base/array", "dojo/has",
 		zeroLine: 0
 	});
 =====*/
-
-	var purgeGroup = dfr.lambda("item.purgeGroup()");
 
 	var DEFAULT_ANIMATION_LENGTH = 1200;	// in ms
 
@@ -219,7 +217,7 @@ define(["dojo/_base/lang", "dojo/_base/declare", "dojo/_base/array", "dojo/has",
 			this.dirty = this.isDirty();
 			var s;
 			if(this.dirty){
-				arr.forEach(this.series, purgeGroup);
+				arr.forEach(this.series, dc.purgeGroup);
 				this._eventSeries = {};
 				this.cleanGroup();
 				this.getGroup().setTransform(null);

--- a/charting/plot2d/OHLC.js
+++ b/charting/plot2d/OHLC.js
@@ -1,8 +1,6 @@
 define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has", "./CartesianBase", "./_PlotEvents", "./common",
-	"dojox/lang/functional", "dojox/lang/functional/reversed", "dojox/lang/utils", "dojox/gfx/fx"],
-	function(lang, arr, declare, has, CartesianBase, _PlotEvents, dc, df, dfr, du, fx){
-
-	var purgeGroup = dfr.lambda("item.purgeGroup()");
+	"dojox/lang/functional", "dojox/lang/utils", "dojox/gfx/fx"],
+	function(lang, arr, declare, has, CartesianBase, _PlotEvents, dc, df, du, fx){
 
 	//	Candlesticks are based on the Bars plot type; we expect the following passed
 	//	as values in a series:
@@ -105,7 +103,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 			this.resetEvents();
 			this.dirty = this.isDirty();
 			if(this.dirty){
-				arr.forEach(this.series, purgeGroup);
+				arr.forEach(this.series, dc.purgeGroup);
 				this._eventSeries = {};
 				this.cleanGroup();
 				var s = this.getGroup();

--- a/charting/plot2d/Scatter.js
+++ b/charting/plot2d/Scatter.js
@@ -1,8 +1,6 @@
 define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has", "./CartesianBase", "./_PlotEvents", "./common",
-	"dojox/lang/functional", "dojox/lang/functional/reversed", "dojox/lang/utils", "dojox/gfx/fx", "dojox/gfx/gradutils"],
-	function(lang, arr, declare, has, CartesianBase, _PlotEvents, dc, df, dfr, du, fx, gradutils){
-
-	var purgeGroup = dfr.lambda("item.purgeGroup()");
+	"dojox/lang/functional", "dojox/lang/utils", "dojox/gfx/fx", "dojox/gfx/gradutils"],
+	function(lang, arr, declare, has, CartesianBase, _PlotEvents, dc, df, du, fx, gradutils){
 
 	return declare("dojox.charting.plot2d.Scatter", [CartesianBase, _PlotEvents], {
 		// summary:
@@ -51,7 +49,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "dojo/has",
 			this.dirty = this.isDirty();
 			var s;
 			if(this.dirty){
-				arr.forEach(this.series, purgeGroup);
+				arr.forEach(this.series, dc.purgeGroup);
 				this._eventSeries = {};
 				this.cleanGroup();
 				s = this.getGroup();

--- a/charting/plot2d/common.js
+++ b/charting/plot2d/common.js
@@ -1,10 +1,10 @@
-define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/Color", 
-		"dojox/gfx", "dojox/lang/functional", "../scaler/common"], 
+define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/Color",
+		"dojox/gfx", "dojox/lang/functional", "../scaler/common"],
 	function(lang, arr, Color, g, df, sc){
-	
+
 	var common = lang.getObject("dojox.charting.plot2d.common", true);
-	
-	return lang.mixin(common, {	
+
+	return lang.mixin(common, {
 		doIfLoaded: sc.doIfLoaded,
 		makeStroke: function(stroke){
 			if(!stroke){ return stroke; }
@@ -201,7 +201,7 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/Color",
 			});
 			return p.join(" ");
 		},
-		
+
 		getLabel: function(/*Number*/number, /*Boolean*/fixed, /*Number*/precision){
 			return sc.doIfLoaded("dojo/number", function(numberLib){
 				return (fixed ? numberLib.format(number, {places : precision}) :
@@ -209,6 +209,10 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/Color",
 			}, function(){
 				return fixed ? number.toFixed(precision) : number.toString();
 			});
+		},
+
+		purgeGroup: function (item) {
+			return item.purgeGroup();
 		}
 	});
 });

--- a/gfx/_base.js
+++ b/gfx/_base.js
@@ -8,13 +8,13 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 
 	var g = lang.getObject("dojox.gfx", true),
 		b = g._base = {};
-	
+
 	// candidates for dojox.style (work on VML and SVG nodes)
 	g._hasClass = function(/*DomNode*/node, /*String*/classStr){
 		// summary:
 		//		Returns whether or not the specified classes are a portion of the
 		//		class list currently applied to the node.
-		
+
 		// return (new RegExp('(^|\\s+)'+classStr+'(\\s+|$)')).test(node.className)	// Boolean
 		var cls = node.getAttribute("className");
 		return cls && (" " + cls + " ").indexOf(" " + classStr + " ") >= 0;  // Boolean
@@ -52,7 +52,7 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 			'x-small': 0, 'small': 0, 'medium': 0, 'large': 0, 'x-large': 0,
 			'xx-large': 0
 		};
-		var p, oldStyle;	
+		var p, oldStyle;
 		if(has("ie")){
 			//	We do a font-size fix if and only if one isn't applied already.
 			// NOTE: If someone set the fontSize on the HTML Element, this will kill it.
@@ -237,22 +237,22 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 		//		The join style to use when combining path segments. Default value 4.
 		join: 4
 	};
-	
+
 	g.Fill = {
 		// summary:
 		//		Defines how to fill a shape. Four types of fills can be used: solid, linear gradient, radial gradient and pattern.
 		//		See dojox/gfx.LinearGradient, dojox/gfx.RadialGradient and dojox/gfx.Pattern respectively for more information about the properties supported by each type.
-		
+
 		// type: String?
 		//		The type of fill. One of 'linear', 'radial', 'pattern' or undefined. If not specified, a solid fill is assumed.
 		type:"",
-		
+
 		// color: String|dojo/Color?
 		//		The color of a solid fill type.
 		color:null,
-		
+
 	};
-	
+
 	g.LinearGradient = {
 		// summary:
 		//		An object defining the default stylistic properties used for Linear Gradient fills.
@@ -284,7 +284,7 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 		//		Default value, [{ offset: 0, color: 'black'},{offset: 1, color: 'white'}], is a gradient from black to white.
 		colors: []
 	};
-	
+
 	g.RadialGradient = {
 		// summary:
 		//		Specifies the properties for RadialGradients using in fills patterns.
@@ -311,7 +311,7 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 		//		Default value, [{ offset: 0, color: 'black'},{offset: 1, color: 'white'}], is a gradient from black to white.
 		colors: []
 	};
-	
+
 	g.Pattern = {
 		// summary:
 		//		An object specifying the default properties for a Pattern using in fill operations.
@@ -370,27 +370,27 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 	g.Font = {
 		// summary:
 		//		An object specifying the properties for a Font used in text operations.
-	
+
 		// type: String
 		//		Specifies this object is a Font, value 'font'.
 		type: "font",
-	
+
 		// style: String
 		//		The font style, one of 'normal', 'bold', default value 'normal'.
 		style: "normal",
-	
+
 		// variant: String
 		//		The font variant, one of 'normal', ... , default value 'normal'.
 		variant: "normal",
-	
+
 		// weight: String
 		//		The font weight, one of 'normal', ..., default value 'normal'.
 		weight: "normal",
-	
+
 		// size: String
 		//		The font size (including units), default value '10pt'.
 		size: "10pt",
-	
+
 		// family: String
 		//		The font family, one of 'serif', 'sanserif', ..., default value 'serif'.
 		family: "serif"
@@ -409,7 +409,7 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 
 			// type: String
 			//		Specifies this object is a Path, default value 'path'.
-			type: "path", 
+			type: "path",
 
 			// path: String
 			//		The path commands. See W32C SVG 1.0 specification.
@@ -773,7 +773,7 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 				if(t){
 					return new t();
 				}
-				t = typeCtorCache[type] = new Function();
+				t = typeCtorCache[type] = function () {};
 				t.prototype = g[ "default" + type ];
 				return new t();
 			}
@@ -1000,7 +1000,7 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 			}
 		}
 	});
-	
+
 	/*=====
 		g.createSurface = function(parentNode, width, height){
 			// summary:
@@ -1019,6 +1019,6 @@ function(kernel, lang, Color, has, win, arr, dom, domConstruct, domGeom){
 			//		private
 		};
 	=====*/
-	
+
 	return g; // defaults object api
 });

--- a/gfx/silverlight.js
+++ b/gfx/silverlight.js
@@ -1,4 +1,4 @@
-define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_base/Color", 
+define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_base/Color",
 		"dojo/on", "dojo/_base/array", "dojo/dom-geometry", "dojo/dom", "dojo/_base/sniff",
 		"./_base", "./shape", "./path", "./registry"],
   function(kernel,lang,declare,color,on,arr,domGeom,dom,has,g,gs,pathLib){
@@ -256,7 +256,7 @@ define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_bas
 			//		returns the adjusted ("real") transformation matrix
 			return this.matrix;	// dojox/gfx/matrix.Matrix2D
 		},
-		
+
 		setClip: function(clip){
 			// summary:
 			//		sets the clipping area of this shape.
@@ -267,8 +267,8 @@ define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_bas
 			this.inherited(arguments);
 			var r = this.rawNode;
 			if(clip){
-				var clipType = clip ? "width" in clip ? "rect" : 
-								"cx" in clip ? "ellipse" : 
+				var clipType = clip ? "width" in clip ? "rect" :
+								"cx" in clip ? "ellipse" :
 								"points" in clip ? "polyline" : "d" in clip ? "path" : null : null;
 				if(clip && !clipType){
 					return this;
@@ -328,7 +328,7 @@ define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_bas
 			//		a Sliverlight node
 			this.rawNode = rawNode;
 			this.rawNode.tag = this.getUID();
-			
+
 		},
 		destroy: function(){
 			// summary:
@@ -641,7 +641,7 @@ define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_bas
 	});
 	sl.TextPath.nodeType = "text";
 
-	var surfaces = {}, nullFunc = new Function;
+	var surfaces = {}, nullFunc = function () {};
 
 	sl.Surface = declare("dojox.gfx.silverlight.Surface", gs.Surface, {
 		// summary:
@@ -889,13 +889,13 @@ define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_bas
 			if(a.source){
 				// support silverlight 2.0
 				ev.target = a.source;
-				var gfxId = ev.target.tag;				
+				var gfxId = ev.target.tag;
 				ev.gfxTarget = gs.byId(gfxId);
 			}
 		}catch(e){
 			// a.source does not exist in 1.0
 		}
-	
+
 		if(a){
 			try{
 				ev.ctrlKey = a.ctrl;
@@ -914,7 +914,7 @@ define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_bas
 		}
 		return ev;
 	}
-	
+
 	function keyFix(s, a){
 		var ev = {
 			keyCode:  a.platformKeyCode,
@@ -932,7 +932,7 @@ define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_bas
 		}
 		return ev;
 	}
-	
+
 	var eventNames = {
 		onclick:		{name: "MouseLeftButtonUp", fix: mouseFix},
 		onmouseenter:	{name: "MouseEnter", fix: mouseFix},
@@ -945,7 +945,7 @@ define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_bas
 		onkeydown:		{name: "KeyDown", fix: keyFix},
 		onkeyup:		{name: "KeyUp", fix: keyFix}
 	};
-	
+
 	var eventsProcessing = {
 		connect: function(name, object, method){
 			return this.on(name, method ? lang.hitch(object, method) : object);
@@ -976,17 +976,16 @@ define(["dojo/_base/kernel", "dojo/_base/lang", "dojo/_base/declare", "dojo/_bas
 			return token.remove();
 		}
 	};
-	
+
 	lang.extend(sl.Shape, eventsProcessing);
 	lang.extend(sl.Surface, eventsProcessing);
-	
+
 	// patch dojox/gfx
 	g.equalSources = function(a, b){
 		// summary:
 		//		compares event sources, returns true if they are equal
 		return a && b && a.equals(b);
 	};
-	
+
 	return sl;
 });
-


### PR DESCRIPTION
Fixes #312

Remove usage of `new Function()`

This PR addresses the most common CSP issues with the charting code (and its gfx dependencies).

The `Chart` widget, when used with a [declarative data provider](https://github.com/dojo/dojox/blob/d6b93d9e76752363a402bef31473ce2d2ae356d7/charting/widget/Chart.js#L107-L163), makes more extensive use of `eval` and `dojox/functional.lambda` and remains unaddressed in this PR. Using this widget this way is cumbersome and not recommended, and hopefully not being done in the wild.