### PR TITLE
Change block-scoped functions to named function expressions

### DIFF
--- a/charting/action2d/_IndicatorElement.js
+++ b/charting/action2d/_IndicatorElement.js
@@ -284,13 +284,13 @@ define(["dojo/_base/lang", "dojo/_base/array", "dojo/_base/declare", "../plot2d/
 			_checkXCoords: function(cp1, cp2){
 				if(this.chart.isRightToLeft() && this.isDirty()){
 					var offset = this.chart.node.offsetLeft;
-					function transform(plot, cp) {
+					var transform = function transform(plot, cp) {
 						var x = cp.x - offset;
 						var shift = (plot.chart.offsets.l - plot.chart.offsets.r);
 						var transformed_x = plot.chart.dim.width + shift - x;
 
 						return transformed_x + offset;
-					}
+					};
 					if(cp1){
 						cp1.x = transform(this, cp1);
 					}

--- a/embed/Quicktime.js
+++ b/embed/Quicktime.js
@@ -49,7 +49,7 @@ define([
 				if(o!==undefined){
 					//	pull the qt version too
 					var v = o.QuickTimeVersion.toString(16);
-					function p(i){ return (v.substring(i, i+1)-0) || 0; }
+					var p = function p(i){ return (v.substring(i, i+1)-0) || 0; };
 					qtVersion = {
 						major: p(0),
 						minor: p(1),
@@ -63,7 +63,7 @@ define([
 
 		qtMarkup = function(kwArgs){
 			if(!installed){ return { id: null, markup: getQTMarkup }; }
-			
+
 			kwArgs = prep(kwArgs);
 			if(!kwArgs){ return null; }
 			var s = '<object classid="clsid:02BF25D5-8C17-4B23-BC80-D3488ABDDC6B" '
@@ -196,7 +196,7 @@ define([
 			if(!(node = domUtil.byId(node))){
 				node=domConstruct.create("div", { id:o.id+"-container" }, windowUtil.body());
 			}
-			
+
 			if(o){
 				node.innerHTML = o.markup;
 				if(o.id){
@@ -215,7 +215,7 @@ define([
 			top = "-1000px",
 			widthHeight = "1px";
 
-		function getVer(){
+		var getVer = function getVer(){
 			setTimeout(function(){
 				var qt = document[o.id],
 					n = domUtil.byId(id);
@@ -237,7 +237,7 @@ define([
 
 				if(!c && n){ domConstruct.destroy(n); }
 			}, 20);
-		}
+		};
 
 		domConstruct.create("div", {
 			innerHTML: o.markup,

--- a/store/db/SQL.js
+++ b/store/db/SQL.js
@@ -120,7 +120,7 @@ define(['dojo/_base/declare', 'dojo/Deferred', 'dojo/when', 'dojo/store/util/Que
 			cols.push('__extra');
 			vals.push('?');
 			params.push(JSON.stringify(extra));
-			
+
 			var idColumn = this.idProperty;
 			if(this.identifyGeneratedKey){
 				params.idColumn = idColumn;
@@ -217,7 +217,7 @@ define(['dojo/_base/declare', 'dojo/Deferred', 'dojo/when', 'dojo/store/util/Que
 				var conditions = [];
 				for(var i in query){
 					var filterValue = query[i];
-					function convertWildcard(value){
+					var convertWildcard = function convertWildcard(value){
 						// convert to LIKE if it ends with a *
 						var wildcard = value && value.match && value.match(wildcardRe);
 						if(wildcard){
@@ -226,13 +226,13 @@ define(['dojo/_base/declare', 'dojo/Deferred', 'dojo/when', 'dojo/store/util/Que
 						}
 						params.push(value);
 						return '=?';
-					}
+					};
 					if(filterValue){
 						if(filterValue.contains){
 							// search within the repeating table
 							var repeatingTable = store.table + '_repeating_' + i;
 							conditions.push(filterValue.contains.map(function(value){
-								return store.idProperty + ' IN (SELECT id FROM ' + repeatingTable + ' WHERE ' + 
+								return store.idProperty + ' IN (SELECT id FROM ' + repeatingTable + ' WHERE ' +
 									'value' + convertWildcard(value) + ')';
 							}).join(' AND '));
 							continue;
@@ -261,7 +261,7 @@ define(['dojo/_base/declare', 'dojo/Deferred', 'dojo/when', 'dojo/store/util/Que
 				}
 				return conditions.join(' AND ');
 			}
-			
+
 			if(options.sort){
 				condition += ' ORDER BY ' +
 				options.sort.map(function(sort){
@@ -316,6 +316,6 @@ define(['dojo/_base/declare', 'dojo/Deferred', 'dojo/when', 'dojo/store/util/Que
 			}
 			return deferred.promise;
 		}
-		
+
 	});
 });


### PR DESCRIPTION
With the addition of block scope to ES6 it has become impractical for tools like Google Closure Compiler to handle block-scoped functions in pre-ES6 code and they are flagged as errors.

This PR ensures that `dojox` can still be built if the build profile sets `optimizeOptions.languageIn` to `'ECMASCRIPT3'` with versions of Google Closure Compiler that support ES6. See dojo/util#83