### PR TITLE
Use this.name properly so widget in form behaves.

### DIFF
--- a/form/Rating.js
+++ b/form/Rating.js
@@ -36,12 +36,12 @@ define([
 			//		Build the templateString. The number of stars is given by this.numStars,
 			//		which is normally an attribute to the widget node.
 
-			var radioName = 'rating-' + Math.random().toString(36).substring(2);
+			this.name = this.name || 'rating-' + Math.random().toString(36).substring(2);
 
 			// The radio input used to display and select stars
 			var starTpl = '<label class="dojoxRatingStar dijitInline ${hidden}">' +
 				'<span class="dojoxRatingLabel">${value} stars</span>' +
-			 	'<input type="radio" name="' + radioName + '" value="${value}" dojoAttachPoint="focusNode" class="dojoxRatingInput">' +
+			 	'<input type="radio" name="' + this.name + '" value="${value}" dojoAttachPoint="focusNode" class="dojoxRatingInput">' +
 				'</label>';
 
 			// The hidden value node is attached as "focusNode" because tabIndex, id, etc. are getting mapped there.

--- a/form/tests/test_Rating.html
+++ b/form/tests/test_Rating.html
@@ -90,16 +90,24 @@
 		dojo.require("dijit.form.FilteringSelect");
 		dojo.require("dijit.form.Button");
 	</script>
-	<form dojoType="dijit.form.Form">
+	<form jsId="rating2form" dojoType="dijit.form.Form">
 		<select dojoType="dijit.form.FilteringSelect">
 			<option>Does</option>
 			<option>this</option>
 			<option>work?</option>
 		</select>
 		<br /><br />
-		<div dojoType="dojox.form.Rating" numStars="5" value="1"></div>
+		<div jsId="rating2" dojoType="dojox.form.Rating" numStars="5" value="1" name="rating_widget_2"></div>
 		<br /><br />
-		<button dojoType="dijit.form.Button">Click me</button>
+		<button dojoType="dijit.form.Button">
+			<script type="dojo/event" data-dojo-event="onClick">
+				dojo.query('#rating2Value')[0].innerHTML = rating2.value;
+				dojo.query('#rating2FormValue')[0].innerHTML = JSON.stringify(rating2form.get('value'));
+			</script>
+			Click me</button>
+		<br /><br />
+		The value is: <b><span id="rating2Value">0</span></b>
+		The form value is: <b><span id="rating2FormValue">-empty-</span></b>
 	</form>
 </body>
 </html>


### PR DESCRIPTION
See Issue #307

Expected behaviour:
A Rating widget with a 'name' attribute in a form that is posted to the server should pass its value using that 'name' parameter.

Actual behaviour:
Rating widget with a 'name' attribute sets its radio inputs to have a rating-<random> name, and the last one's name is then overwritten with the 'name' attribute (I presume this is a FormWidget or similar behaviour acting on focusNode).  Thus not all radio inputs have the same 'name', so clicking on them doesn't trigger the normal 'change' events.

Reproduce the bug:
- Have a Rating widget with a 'name' attribute such as "my-rating" and a numStars of e.g. 5.
- Click the last star.  All stars get highlighted and the value changes to 5.
- Click the last-but-one star.  It gets highlighted and the value changes.
- Click the last star again.  It does not get highlighted nor does the value change.
- Submit the enclosing form.  The value does not get sent in the expected 'my-rating' form field.

Note: The bug is not apparent on the old test_Rating.html page because it doesn't actually test the form behaviour of the Rating widget.

I've updated the widget to use this.name and respect its initial value if set, rather than always cooking up a random name and applying it to the star radio elements.  I also updated the test_Rating.html page so it properly uses the form's value, and in my local env have proven that this actually posts the value in the expected form field.
