### PR TITLE
remove the invalid Flickr API key

### DIFF
--- a/image/FlickrBadge.js
+++ b/image/FlickrBadge.js
@@ -29,7 +29,9 @@ define(["dojo", "dojox/main", "dojox/image/Badge", "dojox/data/FlickrRestStore"]
 		//		of the A tag.
 		target: "",
 
-		apikey: "8c6803164dbc395fb7131c9d54843627",
+		// apikey: your flickr API key
+		//		You can set your flickr API key here
+		apikey: "",
 		_store: null,
 
 		postCreate: function(){


### PR DESCRIPTION
This PR is to remove the invalid Flickr API key in file image/FlickrBadge.js. 
It came up as a security alert in our project that use dojox as a dependency. 
Removing it might benefit others too who might have this issue. 

Thanks!